### PR TITLE
never mind; please delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-jasmine": "~0.1.3",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",


### PR DESCRIPTION
Package.json has an outdated dependency that prevents npm install to finish with error error peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!
Updated karma-requirejs to version 0.2.0 as descrbied on https://github.com/HabitRPG/habitrpg/issues/3061