### PR TITLE
Referees 2018/cookie pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/components/*/*
 !src/components/angular-mocks/angular*.js
 !src/components/angular-touch/angular*.js
 !src/components/angular-touch/angular*.map
+!src/components/angular-cookies/*.js
 !src/components/angular-bootstrap/*.js
 
 !src/components/bootstrap-css/css

--- a/src/components/angular-cookies/angular-cookies.js
+++ b/src/components/angular-cookies/angular-cookies.js
@@ -1,0 +1,206 @@
+/**
+ * @license AngularJS v1.2.20
+ * (c) 2010-2014 Google, Inc. http://angularjs.org
+ * License: MIT
+ */
+(function(window, angular, undefined) {'use strict';
+
+/**
+ * @ngdoc module
+ * @name ngCookies
+ * @description
+ *
+ * # ngCookies
+ *
+ * The `ngCookies` module provides a convenient wrapper for reading and writing browser cookies.
+ *
+ *
+ * <div doc-module-components="ngCookies"></div>
+ *
+ * See {@link ngCookies.$cookies `$cookies`} and
+ * {@link ngCookies.$cookieStore `$cookieStore`} for usage.
+ */
+
+
+angular.module('ngCookies', ['ng']).
+  /**
+   * @ngdoc service
+   * @name $cookies
+   *
+   * @description
+   * Provides read/write access to browser's cookies.
+   *
+   * Only a simple Object is exposed and by adding or removing properties to/from this object, new
+   * cookies are created/deleted at the end of current $eval.
+   * The object's properties can only be strings.
+   *
+   * Requires the {@link ngCookies `ngCookies`} module to be installed.
+   *
+   * @example
+   *
+   * ```js
+   * angular.module('cookiesExample', ['ngCookies'])
+   *   .controller('ExampleController', ['$cookies', function($cookies) {
+   *     // Retrieving a cookie
+   *     var favoriteCookie = $cookies.myFavorite;
+   *     // Setting a cookie
+   *     $cookies.myFavorite = 'oatmeal';
+   *   }]);
+   * ```
+   */
+   factory('$cookies', ['$rootScope', '$browser', function ($rootScope, $browser) {
+      var cookies = {},
+          lastCookies = {},
+          lastBrowserCookies,
+          runEval = false,
+          copy = angular.copy,
+          isUndefined = angular.isUndefined;
+
+      //creates a poller fn that copies all cookies from the $browser to service & inits the service
+      $browser.addPollFn(function() {
+        var currentCookies = $browser.cookies();
+        if (lastBrowserCookies != currentCookies) { //relies on browser.cookies() impl
+          lastBrowserCookies = currentCookies;
+          copy(currentCookies, lastCookies);
+          copy(currentCookies, cookies);
+          if (runEval) $rootScope.$apply();
+        }
+      })();
+
+      runEval = true;
+
+      //at the end of each eval, push cookies
+      //TODO: this should happen before the "delayed" watches fire, because if some cookies are not
+      //      strings or browser refuses to store some cookies, we update the model in the push fn.
+      $rootScope.$watch(push);
+
+      return cookies;
+
+
+      /**
+       * Pushes all the cookies from the service to the browser and verifies if all cookies were
+       * stored.
+       */
+      function push() {
+        var name,
+            value,
+            browserCookies,
+            updated;
+
+        //delete any cookies deleted in $cookies
+        for (name in lastCookies) {
+          if (isUndefined(cookies[name])) {
+            $browser.cookies(name, undefined);
+          }
+        }
+
+        //update all cookies updated in $cookies
+        for(name in cookies) {
+          value = cookies[name];
+          if (!angular.isString(value)) {
+            value = '' + value;
+            cookies[name] = value;
+          }
+          if (value !== lastCookies[name]) {
+            $browser.cookies(name, value);
+            updated = true;
+          }
+        }
+
+        //verify what was actually stored
+        if (updated){
+          updated = false;
+          browserCookies = $browser.cookies();
+
+          for (name in cookies) {
+            if (cookies[name] !== browserCookies[name]) {
+              //delete or reset all cookies that the browser dropped from $cookies
+              if (isUndefined(browserCookies[name])) {
+                delete cookies[name];
+              } else {
+                cookies[name] = browserCookies[name];
+              }
+              updated = true;
+            }
+          }
+        }
+      }
+    }]).
+
+
+  /**
+   * @ngdoc service
+   * @name $cookieStore
+   * @requires $cookies
+   *
+   * @description
+   * Provides a key-value (string-object) storage, that is backed by session cookies.
+   * Objects put or retrieved from this storage are automatically serialized or
+   * deserialized by angular's toJson/fromJson.
+   *
+   * Requires the {@link ngCookies `ngCookies`} module to be installed.
+   *
+   * @example
+   *
+   * ```js
+   * angular.module('cookieStoreExample', ['ngCookies'])
+   *   .controller('ExampleController', ['$cookieStore', function($cookieStore) {
+   *     // Put cookie
+   *     $cookieStore.put('myFavorite','oatmeal');
+   *     // Get cookie
+   *     var favoriteCookie = $cookieStore.get('myFavorite');
+   *     // Removing a cookie
+   *     $cookieStore.remove('myFavorite');
+   *   }]);
+   * ```
+   */
+   factory('$cookieStore', ['$cookies', function($cookies) {
+
+      return {
+        /**
+         * @ngdoc method
+         * @name $cookieStore#get
+         *
+         * @description
+         * Returns the value of given cookie key
+         *
+         * @param {string} key Id to use for lookup.
+         * @returns {Object} Deserialized cookie value.
+         */
+        get: function(key) {
+          var value = $cookies[key];
+          return value ? angular.fromJson(value) : value;
+        },
+
+        /**
+         * @ngdoc method
+         * @name $cookieStore#put
+         *
+         * @description
+         * Sets a value for given cookie key
+         *
+         * @param {string} key Id for the `value`.
+         * @param {Object} value Value to be stored.
+         */
+        put: function(key, value) {
+          $cookies[key] = angular.toJson(value);
+        },
+
+        /**
+         * @ngdoc method
+         * @name $cookieStore#remove
+         *
+         * @description
+         * Remove given cookie
+         *
+         * @param {string} key Id of the key-value pair to delete.
+         */
+        remove: function(key) {
+          delete $cookies[key];
+        }
+      };
+
+    }]);
+
+
+})(window, window.angular);

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -9,6 +9,7 @@ var require = {
         'angular': '../components/angular/angular.min',
         'angular-sanitize': '../components/angular-sanitize/angular-sanitize.min',
         'angular-touch': '../components/angular-touch/angular-touch.min',
+        'angular-cookies': '../components/angular-cookies/angular-cookies',
         'angular-bootstrap': '../components/angular-bootstrap/ui-bootstrap-tpls',
         'idbstore':'../components/idbwrapper/idbstore',
         'signaturepad':'../components/signature-pad/jquery.signaturepad.min'
@@ -27,6 +28,9 @@ var require = {
             deps: ['angular']
         },
         'angular-sanitize': {
+            deps: ['angular']
+        },
+        'angular-cookies': {
             deps: ['angular']
         }
     }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -32,7 +32,6 @@ define([
         function($scope, session ,$cookies) {
             log('init main ctrl');
             $scope.drawer = 'views/drawer.html';
-            $scope.scoringPages = ['scoresheet','settings'];
             $scope.validationErrors = [];
             $scope.drawerVisible = false;
 
@@ -53,7 +52,7 @@ define([
                     ];
                 }
 
-                $scope.currentPage = $cookies['page'] || $scope.pages[0];
+                $scope.currentPage = $scope.pages.filter(page => page.name === $cookies['page'])[0] || $scope.pages[0];
             })
 
             $scope.$on('validationError',function(e,validationErrors) {
@@ -70,7 +69,7 @@ define([
 
             $scope.setPage = function(page) {
                 $scope.currentPage = page;
-                $cookies['page'] = page;
+                $cookies['page'] = page.name;
                 $('body').scrollTop(0);
                 $scope.drawerVisible = false;
             };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,6 +15,7 @@ define([
     'tests/indexedDBTest',
     'angular-bootstrap',
     'angular-touch',
+    'angular-cookies',
     'angular-sanitize',
     'angular'
 ],function(log,settings,teams,scoresheet,scores,ranking,services,directives,size,filters,indexFilter,fsTest,dbTest) {
@@ -27,8 +28,8 @@ define([
     //initialize main controller and load main view
     //load other main views to create dynamic views for different device layouts
     angular.module('main',[]).controller('mainCtrl',[
-        '$scope', 'session',
-        function($scope, session) {
+        '$scope', 'session', '$cookies',
+        function($scope, session ,$cookies) {
             log('init main ctrl');
             $scope.drawer = 'views/drawer.html';
             $scope.scoringPages = ['scoresheet','settings'];
@@ -52,7 +53,7 @@ define([
                     ];
                 }
 
-                $scope.currentPage = $scope.pages[0];
+                $scope.currentPage = $cookies['page'] || $scope.pages[0];
             })
 
             $scope.$on('validationError',function(e,validationErrors) {
@@ -69,6 +70,7 @@ define([
 
             $scope.setPage = function(page) {
                 $scope.currentPage = page;
+                $cookies['page'] = page;
                 $('body').scrollTop(0);
                 $scope.drawerVisible = false;
             };
@@ -100,6 +102,7 @@ define([
         'ui.bootstrap',
         'ngSanitize',
         'ngTouch',
+        'ngCookies',
         settings.name,
         teams.name,
         scoresheet.name,


### PR DESCRIPTION
I didn't say before why I think this is a good idea.
It happened to me a lot while using the system, I refreshed the page to see some new rankings or something and it threw me back to the scoresheet. I thought to myself: why shouldn't it stay on the same page?
After that, I implemented it in order to use this instead of the "refresh scores" button - just refresh the page, there's even a hotkey for it - but in the end it wasn't needed for the scores automatic route. So I ended up leaving it.

To be fare, it's not as important to me as other PRs, but I think it's a small thing that can change the system to be just a little better. If we end up deciding not to do it, I won't argue to much over it.