### PR TITLE
Added sorting icons to the Ranking and the Scorekeeping pages

### DIFF
--- a/spec/controllers/ExportRankingDialiogControllerSpec.js
+++ b/spec/controllers/ExportRankingDialiogControllerSpec.js
@@ -16,7 +16,7 @@ describe('ExportRankingDialogController',function() {
             $timeout = _$timeout_;
             scoresMock = createScoresMock($q,fakeScoreboard);
             handshakeMock = createHandshakeMock($q);
-            stagesMock = createStagesMock();
+            stagesMock = createStagesMock($q);
             controller = $controller('ExportRankingDialogController', {
                 '$scope': $scope,
                 '$scores': scoresMock,

--- a/spec/filters/indexSpec.js
+++ b/spec/filters/indexSpec.js
@@ -1,7 +1,8 @@
 describe('indexFilter',function() {
     var ngFilters = factory('filters/ng-filters');
     var module = factory('filters/index',{
-        'filters/ng-filters': ngFilters
+        'filters/ng-filters': ngFilters,
+        'services/log': logMock
     });
 
     var index;

--- a/spec/mocks/scoresMock.js
+++ b/spec/mocks/scoresMock.js
@@ -8,6 +8,7 @@ function createScoresMock($q,scoreboard) {
             score: 2,
             index: 1
         }],
+        init: jasmine.createSpy('scoreInitSpy').and.returnValue($q.when()),
         scoreboard: scoreboard,
         remove: jasmine.createSpy('scoreRemoveSpy'),
         load: jasmine.createSpy('scoreLoadSpy'),

--- a/spec/mocks/stagesMock.js
+++ b/spec/mocks/stagesMock.js
@@ -1,4 +1,4 @@
-function createStagesMock() {
+function createStagesMock($q) {
     var stages = [
         { id: "practice", name: "Oefenrondes", rounds: 2, $rounds: [1, 2] },
         { id: "qualifying", name: "Voorrondes", rounds: 3, $rounds: [1, 2, 3] },
@@ -9,6 +9,7 @@ function createStagesMock() {
     return {
         stages: stages,
         allStages: stages,
+        init: jasmine.createSpy('stagesInitSpy').and.returnValue($q.when()),
         get: function(id) {
             var i;
             for (i = 0; i < stages.length; i++) {

--- a/spec/views/rankingSpec.js
+++ b/spec/views/rankingSpec.js
@@ -79,7 +79,7 @@ describe('ranking', function() {
                 sort: 'foo'
             };
             expect($scope.sortIcon(stage)).toEqual('');
-            expect($scope.sortIcon(stage,'foo')).toEqual('icon-sort-up');
+            expect($scope.sortIcon(stage,'foo')).toEqual('arrow_drop_up');
         });
         it('should give the up icon when col is sorted in reverse',function() {
             var stage = {
@@ -87,15 +87,15 @@ describe('ranking', function() {
                 rev: true
             };
             expect($scope.sortIcon(stage)).toEqual('');
-            expect($scope.sortIcon(stage,'foo')).toEqual('icon-sort-down');
+            expect($scope.sortIcon(stage,'foo')).toEqual('arrow_drop_down');
         });
 
         //default sort order stuff, needs a bit of refactoring
         it('should report a default sorting for any stage',function() {
             var stage = {};
-            expect($scope.sortIcon(stage,'rank')).toEqual('icon-sort-up');
+            expect($scope.sortIcon(stage,'rank')).toEqual('arrow_drop_up');
             $scope.rev = true;
-            expect($scope.sortIcon(stage,'rank')).toEqual('icon-sort-down');
+            expect($scope.sortIcon(stage,'rank')).toEqual('arrow_drop_down');
         });
     });
 

--- a/spec/views/rankingSpec.js
+++ b/spec/views/rankingSpec.js
@@ -18,7 +18,7 @@ describe('ranking', function() {
             $scope = $rootScope.$new();
             scoresMock = createScoresMock($q);
             handshakeMock = createHandshakeMock($q);
-            stagesMock = createStagesMock();
+            stagesMock = createStagesMock($q);
             messageMock = createMessageMock();
             controller = $controller('rankingCtrl', {
                 '$scope': $scope,
@@ -32,8 +32,6 @@ describe('ranking', function() {
 
     describe('initialization', function() {
         it('should initialize', function() {
-            expect($scope.sort).toEqual('rank');
-            expect($scope.rev).toEqual(false);
             expect($scope.csvdata).toEqual({});
             expect($scope.csvname).toEqual({});
         });
@@ -92,10 +90,10 @@ describe('ranking', function() {
 
         //default sort order stuff, needs a bit of refactoring
         it('should report a default sorting for any stage',function() {
-            var stage = {};
-            expect($scope.sortIcon(stage,'rank')).toEqual('arrow_drop_up');
-            $scope.rev = true;
-            expect($scope.sortIcon(stage,'rank')).toEqual('arrow_drop_down');
+            $scope.$digest();//resolve all promises
+            $scope.stages.forEach(function (stage) {
+                expect($scope.sortIcon(stage,'rank')).toEqual('arrow_drop_up');
+            });
         });
     });
 

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -23,6 +23,7 @@ describe('scores', function() {
             });
         });
         $window.alert = jasmine.createSpy('alertSpy');
+        $scope.$digest();//resolve all initialization promises
     });
 
     describe('initialization', function() {

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -14,7 +14,7 @@ describe('scores', function() {
             $q = _$q_;
             scoresMock = createScoresMock($q);
             teamsMock = createTeamsMock();
-            stagesMock = createStagesMock();
+            stagesMock = createStagesMock($q);
             controller = $controller('scoresCtrl', {
                 '$scope': $scope,
                 '$scores': scoresMock,

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -131,4 +131,25 @@ describe('scores', function() {
             expect(scoresMock.load).toHaveBeenCalled();
         });
     });
+
+    describe('sortIcon',function() {
+        it('should give the up icon when col is sorted',function() {
+            $scope.sort = 'foo';
+            expect($scope.sortIcon('bla')).toEqual('');
+            expect($scope.sortIcon('foo')).toEqual('arrow_drop_down');
+        });
+        it('should give the up icon when col is sorted in reverse', function () {
+            $scope.sort = 'foo';
+            $scope.rev = true;
+            expect($scope.sortIcon('bla')).toEqual('');
+            expect($scope.sortIcon('foo')).toEqual('arrow_drop_down');
+        });
+
+        //default sort order stuff, needs a bit of refactoring
+        it('should report a default sorting for any stage',function() {
+            expect($scope.sortIcon('index')).toEqual('arrow_drop_down');
+            $scope.rev = false;
+            expect($scope.sortIcon('index')).toEqual('arrow_drop_up');
+        });
+    });
 });

--- a/spec/views/settingsSpec.js
+++ b/spec/views/settingsSpec.js
@@ -15,7 +15,7 @@ describe('settings', function() {
             $scope = $rootScope.$new();
             settingsMock = createSettingsMock($q, {});
             handshakeMock = createHandshakeMock($q);
-            stagesMock = createStagesMock();
+            stagesMock = createStagesMock($q);
             controller = $controller('settingsCtrl', {
                 '$scope': $scope,
                 '$stages': stagesMock,

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -327,3 +327,11 @@ button .material-icons {
         display: none !important;
     }
 }
+
+.sortable span{
+    float: left;
+}
+
+.sortable i{
+    float: right;
+}

--- a/src/js/filters/index.js
+++ b/src/js/filters/index.js
@@ -10,19 +10,21 @@
  * Then, use {{score.index}} instead of {{$index}} in e.g. click-handlers.
  */
 define('filters/index',[
-    'filters/ng-filters'
-],function(module) {
+    'filters/ng-filters',
+    'services/log'
+],function(module, log) {
     return module.filter('index', function () {
-        return function (array, index) {
+        return function (array, indexPropertyName) {
             //bail out if not an array-like structure
             if (!(array && array.forEach)) {
+                log("Indexing none-array: " + array);
                 return array;
             }
-            if (!index) {
-                index = 'index';
+            if (!indexPropertyName) {
+                indexPropertyName = 'index';
             }
             array.forEach(function(item,i) {
-                item[index] = i;
+                item[indexPropertyName] = i;
             });
             return array;
         };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -17,7 +17,7 @@ define([
     'angular-touch',
     'angular-sanitize',
     'angular'
-],function(log,settings,teams,scoresheet,scores,ranking,services,directives,size,filters,indexFilter,fsTest,dbTest) {
+], function (log, session, settings, teams, scoresheet, scores, ranking, services, directives, size, filters, indexFilter, fsTest, dbTest) {
 
     log('device ready');
 

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -14,10 +14,6 @@ define('views/ranking',[
         function($scope, $scores, $stages, $handshake, $message) {
             log('init ranking ctrl');
 
-            // temporary default sort values
-            $scope.sort = 'rank';
-            $scope.rev = false;
-
             $scope.scores = $scores;
 
             $scope.exportRanking = function() {
@@ -143,7 +139,13 @@ define('views/ranking',[
                 $scope.rebuildCSV($scores.scoreboard);
             }, true);
 
-            $scope.stages = $stages.stages;
+            $stages.init().then(function () {
+                $scope.stages = $stages.stages;
+                $scope.stages.forEach(function (stage) {
+                    stage.sort = 'rank';
+                    stage.rev = false;
+                })
+            });
             $scope.scoreboard = $scores.scoreboard;
 
             $scope.getRoundLabel = function(round){

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -66,24 +66,14 @@ define('views/ranking',[
             };
 
             $scope.sortIcon = function(stage, col){
-                // got into trouble with a default sort order here...
-                var icon = '';
-                if (stage.sort == col) {
-                    if (stage.rev){
-                        icon = 'arrow_drop_down';
-                    } else {
-                        icon = 'arrow_drop_up';
-                    }
-                } else if (stage.sort === undefined && col == $scope.sort) {
-                    if (stage.rev === undefined && $scope.rev) {
-                        icon = 'arrow_drop_down';
-                    } else {
-                        icon = 'arrow_drop_up';
-                    }
-                } else {
-                    icon = ''; // no icon if column is not sorted
+                if(!angular.equals(stage.sort, col)){
+                    return '';
                 }
-                return icon;
+                if (stage.rev) {
+                    return 'arrow_drop_down';
+                } else {
+                    return 'arrow_drop_up';
+                }
             };
 
             $scope.toggle = function(stage) {

--- a/src/js/views/ranking.js
+++ b/src/js/views/ranking.js
@@ -70,15 +70,15 @@ define('views/ranking',[
                 var icon = '';
                 if (stage.sort == col) {
                     if (stage.rev){
-                        icon = 'icon-sort-down';
+                        icon = 'arrow_drop_down';
                     } else {
-                        icon = 'icon-sort-up';
+                        icon = 'arrow_drop_up';
                     }
                 } else if (stage.sort === undefined && col == $scope.sort) {
                     if (stage.rev === undefined && $scope.rev) {
-                        icon = 'icon-sort-down';
+                        icon = 'arrow_drop_down';
                     } else {
-                        icon = 'icon-sort-up';
+                        icon = 'arrow_drop_up';
                     }
                 } else {
                     icon = ''; // no icon if column is not sorted
@@ -159,7 +159,7 @@ define('views/ranking',[
             $scope.getRoundLabel = function(round){
                 return "Round " + round;
             };
-            
+
 
         }
     ]);

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -13,7 +13,8 @@ define('views/scores',[
             $scope.sort = 'index';
             $scope.rev = true;
 
-            $scope.scores = $scores.scores;
+            $scope.scores = [];
+            $scores.init().then(() => $scope.scores = $scores.scores);
             $scope.stages = $stages.stages;
 
             $scope.doSort = function(col, defaultSort) {

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -22,7 +22,7 @@ define('views/scores',[
             };
 
             $scope.sortIcon = function(col){
-                if(String($scope.sort)!== String(col)){//col and $scope.sort can be arrays, and so this is a quick and dirty way to check for equality
+                if(!angular.equals($scope.sort, col)){
                     return '';
                 }
                 if ($scope.rev) {

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -20,6 +20,18 @@ define('views/scores',[
                 $scope.rev = (String($scope.sort) === String(col)) ? !$scope.rev : !!defaultSort;
                 $scope.sort = col;
             };
+
+            $scope.sortIcon = function(col){
+                if(String($scope.sort)!== String(col)){//col and $scope.sort can be arrays, and so this is a quick and dirty way to check for equality
+                    return '';
+                }
+                if ($scope.rev) {
+                    return 'arrow_drop_down';
+                } else {
+                    return 'arrow_drop_up';
+                }
+            };
+
             $scope.removeScore = function(index) {
                 $scores.remove(index);
                 return $scores.save();

--- a/src/views/dialogs.html
+++ b/src/views/dialogs.html
@@ -186,20 +186,20 @@
                         </button>
                     <p>
                         <a  href="{{exportdata}}" download="{{exportname}}" ng-show="exportvisible"><i class="material-icons">file_download</i> Export naar USB</a>
-                        
+
                         <div ng-hide="true" id="scoreexport">
                             <style>
                                 #bodyranking{
-                                    background-color:#DEDEDE; 
+                                    background-color:#DEDEDE;
                                     background-repeat:no-repeat;
                                 }
-                                #rankingtable{     
+                                #rankingtable{
                                     font-family:"Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", "DejaVu Sans", Verdana, sans-serif;
                                     text-align:center;
                                     width:95%;
-                                    margin-left:auto; 
+                                    margin-left:auto;
                                     margin-right:auto;
-                                
+
                                 }
                                 #scoreexport{
                                     border:1px solid black;
@@ -219,7 +219,7 @@
                                     color:white;
                                     font-size:x-large;
                                     white-space:nowrap;
-                                    
+
                                 }
                                 .top{
                                     background-color:silver;
@@ -229,7 +229,7 @@
                                     background-color:rgba(255, 255, 255, 0.8);
 
                                 }
-                                .out{  
+                                .out{
                                     opacity: 0;
                                     -webkit-transition: opacity 2s ease-in;
                                     -moz-transition: opacity 2s ease-in;
@@ -246,24 +246,24 @@
                                     FLOWAMOUNT        = angular.element(document.querySelector('[ng-controller="rankingCtrl"]')).scope().export.flowAmount;
                                     // The amount of scores always visible at top
                                     FIXEDSHOWNTOP     = angular.element(document.querySelector('[ng-controller="rankingCtrl"]')).scope().export.fixedShownTop;
-                                    // Amount of seconds that the first page shows       
+                                    // Amount of seconds that the first page shows
                                     TIMEFORFRAME1     = angular.element(document.querySelector('[ng-controller="rankingCtrl"]')).scope().export.timeForFrame1;
-                                    // Amount of seconds that each scroll takes      
+                                    // Amount of seconds that each scroll takes
                                     TIMETHROUGHFRAMES = angular.element(document.querySelector('[ng-controller="rankingCtrl"]')).scope().export.timeThroughFrames;
                                     // Amount of scores that move away and appear
                                     FADEATONEGO       = angular.element(document.querySelector('[ng-controller="rankingCtrl"]')).scope().export.fadeAtOneGo;
 
                                     for(var p = 0 ; p <= FIXEDSHOWNTOP -1 ; p++){
                                     document.getElementById('trrow'+p).className = 'top';
-                                        
+
                                     }
                                     for(var q = FIXEDSHOWNTOP ; q <= TOTALAMOUNT -1 ; q++){
                                     document.getElementById('trrow'+q).className = 'all';
-                                        
+
                                     }
                                     for(var x = FLOWAMOUNT; x<(TOTALAMOUNT);x++){
                                         document.getElementById('trrow'+x).style.visibility = 'hidden';
-                                    }   
+                                    }
                                     //alert(amount);
                                     setTimeout(gotoNext,(TIMEFORFRAME1*1000));
                                 }
@@ -305,7 +305,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr ng-repeat="item in filterscoreboard[stageselected.id] | index | orderBy:stageselectedselected.sort:stageselected.rev track by item.team.number" id="trrow{{$index}}">
+                                    <tr ng-repeat="item in filterscoreboard[stageselected.id] | orderBy:stageselectedselected.sort:stageselected.rev track by item.team.number" id="trrow{{$index}}">
                                         <td>{{item.rank}}</td>
                                         <td>{{item.team.number}}</td>
                                         <td><b>{{item.team.name}}</b></td>

--- a/src/views/pages/ranking.html
+++ b/src/views/pages/ranking.html
@@ -41,27 +41,27 @@
                     <tr class="clickable">
                         <th class="span1" ng-click="doSort(stage, 'rank',false)">
                             <span style="float: left;">Rank</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'rank')"></span>
+                            <i style="float: right" class="material-icons">{{sortIcon(stage, 'rank')}}</i>
                         </th>
                         <th class="span1" ng-click="doSort(stage, 'team.number',false)">
                             <span style="float: left;">Team</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'team.number')"></span>
+                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'team.number')}}</i>
                         </th>
                         <th class="span2" ng-click="doSort(stage, 'team.name',false)">
                             <span style="float: left;">Name</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'team.name')"></span>
+                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'team.name')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds > 1" ng-click="doSort(stage, 'highest',true)">
                             <span style="float: left;">Highest</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'highest')"></span>
+                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'highest')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds == 1" ng-click="doSort(stage, 'highest',true)">
                             <span style="float: left;">Score</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'highest')"></span>
+                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'highest')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds > 1" ng-repeat="round in stage.$rounds track by $index" ng-click="doSort(stage, 'scores['+$index+']',true)">
                             <span style="float: left;">Round {{round}}</span>
-                            <span style="float: right;" class="icon" ng-class="sortIcon(stage, 'scores['+$index+']')"></span>
+                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'scores['+$index+']')}}</i>
                         </th>
                         <!-- padding cols -->
                         <th class="span1 clearCell" ng-repeat="col in emptyCols(stage) track by $index"></th>
@@ -69,7 +69,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="item in scoreboard[stage.id] | index | orderBy:stage.sort:stage.rev track by item.team.number">
+                    <tr ng-repeat="item in scoreboard[stage.id]  | orderBy:stage.sort:stage.rev track by item.team.number">
                         <td>{{item.rank}}</td>
                         <td>{{item.team.number}}</td>
                         <td>{{item.team.name}}</td>

--- a/src/views/pages/ranking.html
+++ b/src/views/pages/ranking.html
@@ -38,30 +38,30 @@
                 ng-if="stage.rounds > 0"
             >
                 <thead>
-                    <tr class="clickable">
+                    <tr class="clickable sortable">
                         <th class="span1" ng-click="doSort(stage, 'rank',false)">
-                            <span style="float: left;">Rank</span>
-                            <i style="float: right" class="material-icons">{{sortIcon(stage, 'rank')}}</i>
+                            <span>Rank</span>
+                            <i class="material-icons">{{sortIcon(stage, 'rank')}}</i>
                         </th>
                         <th class="span1" ng-click="doSort(stage, 'team.number',false)">
-                            <span style="float: left;">Team</span>
-                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'team.number')}}</i>
+                            <span>Team</span>
+                             <i class="material-icons">{{sortIcon(stage, 'team.number')}}</i>
                         </th>
                         <th class="span2" ng-click="doSort(stage, 'team.name',false)">
-                            <span style="float: left;">Name</span>
-                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'team.name')}}</i>
+                            <span>Name</span>
+                             <i class="material-icons">{{sortIcon(stage, 'team.name')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds > 1" ng-click="doSort(stage, 'highest',true)">
-                            <span style="float: left;">Highest</span>
-                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'highest')}}</i>
+                            <span>Highest</span>
+                             <i class="material-icons">{{sortIcon(stage, 'highest')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds == 1" ng-click="doSort(stage, 'highest',true)">
-                            <span style="float: left;">Score</span>
-                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'highest')}}</i>
+                            <span>Score</span>
+                             <i class="material-icons">{{sortIcon(stage, 'highest')}}</i>
                         </th>
                         <th class="span1" ng-if="stage.rounds > 1" ng-repeat="round in stage.$rounds track by $index" ng-click="doSort(stage, 'scores['+$index+']',true)">
-                            <span style="float: left;">Round {{round}}</span>
-                             <i style="float: right" class="material-icons">{{sortIcon(stage, 'scores['+$index+']')}}</i>
+                            <span>Round {{round}}</span>
+                             <i class="material-icons">{{sortIcon(stage, 'scores['+$index+']')}}</i>
                         </th>
                         <!-- padding cols -->
                         <th class="span1 clearCell" ng-repeat="col in emptyCols(stage) track by $index"></th>

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -14,19 +14,40 @@
     <p>Showing {{scores.length}} scores.</p>
     <table class="table table-bordered table-striped">
         <thead>
-            <tr>
-                <th ng-click="doSort('index',true)">#</th>
-                <th ng-click="doSort(['stage.index','-index'],false)">Stage</th>
-                <th ng-click="doSort(['stage.index','round','-index'],false)">Round</th>
-                <th ng-click="doSort('table',false)">Table</th>
-                <th ng-click="doSort('team.number',false)">Team</th>
-                <th ng-click="doSort('team.name',false)">Name</th>
-                <th ng-click="doSort('score',true)">Score</th>
+            <tr class="clickable">
+                <th class="span1" ng-click="doSort('index',true)">
+                    <span style="float: left"># </span>
+                    <i style="float: right" class="material-icons">{{sortIcon('index')}}</i>
+                </th>
+                <th class="span3" ng-click="doSort(['stage.index','-index'],false)">
+                    <span style="float: left">Stage </span>
+                    <i style="float: right" class="material-icons">{{sortIcon(['stage.index','-index'])}}</i>
+                </th>
+                <th class="span2" ng-click="doSort(['stage.index','round','-index'],false)">
+                    <span style="float: left">Round </span>
+                    <i style="float: right" class="material-icons">{{sortIcon(['stage.index','round','-index'])}}</i>
+                </th>
+                <th class="span2" ng-click="doSort('table',false)">
+                    <span style="float: left">Table </span>
+                    <i style="float: right" class="material-icons">{{sortIcon('table')}}</i>
+                </th>
+                <th class="span2" ng-click="doSort('team.number',false)">
+                    <span style="float: left">Team </span>
+                    <i style="float: right" class="material-icons">{{sortIcon('team.number')}}</i>
+                </th>
+                <th class="span2" ng-click="doSort('team.name',false)">
+                    <span style="float: left">Name </span>
+                    <i style="float: right" class="material-icons">{{sortIcon('team.name')}}</i>
+                </th>
+                <th class="span2" ng-click="doSort('score',true)">
+                    <span style="float: left">Score </span>
+                    <i style="float: right" class="material-icons">{{sortIcon('score')}}</i>
+                </th>
                 <th>Action</th>
             </tr>
         </thead>
-        <tr ng-repeat="score in scores | index | orderBy:sort:rev track by score.index" ng-class="{error: score.error, warning: score.modified && !score.error}">
-            <td>{{score.index + 1}}</td>
+        <tr ng-repeat="score in scores | orderBy:sort:rev track by $index" ng-class="{error: score.error, warning: score.modified && !score.error}">
+            <td>{{$index + 1}}</td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownStageError'" title="{{score.error.message}}">error</i>
                 <span ng-if="!score.$editing">

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -46,8 +46,8 @@
                 <th>Action</th>
             </tr>
         </thead>
-        <tr ng-repeat="score in scores | orderBy:sort:rev track by $index" ng-class="{error: score.error, warning: score.modified && !score.error}">
-            <td>{{$index + 1}}</td>
+        <tr ng-repeat="score in scores | index | orderBy:sort:rev track by score.index" ng-class="{error: score.error, warning: score.modified && !score.error}">
+            <td>{{score.index + 1}}</td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownStageError'" title="{{score.error.message}}">error</i>
                 <span ng-if="!score.$editing">

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -23,9 +23,9 @@
                     <span >Stage </span>
                     <i class="material-icons">{{sortIcon(['stage.index','-index'])}}</i>
                 </th>
-                <th class="span2" ng-click="doSort(['stage.index','round','-index'],false)">
+                <th class="span2" ng-click="doSort(['round.index','round','-index'],false)">
                     <span >Round </span>
-                    <i class="material-icons">{{sortIcon(['stage.index','round','-index'])}}</i>
+                    <i class="material-icons">{{sortIcon(['round.index','round','-index'])}}</i>
                 </th>
                 <th class="span2" ng-click="doSort('table',false)">
                     <span >Table </span>

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -97,39 +97,39 @@
             <td>
                 <button class="btn"
                     ng-if="!score.published"
-                    ng-click="publishScore(score.index)"
+                    ng-click="publishScore($index)"
                 >
                     Publish
                 </button>
                 <button class="btn"
                     ng-if="score.published"
-                    ng-click="unpublishScore(score.index)"
+                    ng-click="unpublishScore($index)"
                 >
                     Unpublish
                 </button>
                 <button class="btn btn-default"
                     ng-if="!score.$editing"
-                    ng-click="editScore(score.index)"
+                    ng-click="editScore($index)"
                 >
                     <i class="material-icons">mode_edit</i>
                     Edit
                 </button>
                 <button class="btn btn-default"
                     ng-if="score.$editing"
-                    ng-click="finishEditScore(score.index)"
+                    ng-click="finishEditScore($index)"
                 >
                     <i class="material-icons">mode_edit</i>
                     Save
                 </button>
                 <button class="btn btn-danger"
                     ng-if="!score.$editing"
-                    fll-really-message="Are you sure you want to completely remove score {{score.score}} for round {{score.match.round}} of team {{score.team.name}}?" fll-really-click="removeScore(score.index)">
+                    fll-really-message="Are you sure you want to completely remove score {{score.score}} for round {{score.match.round}} of team {{score.team.name}}?" fll-really-click="removeScore($index)">
                     <i class="material-icons">delete</i>
                     Delete
                 </button>
                 <button class="btn btn-default"
                     ng-if="score.$editing"
-                    ng-click="cancelEditScore(score.index)"
+                    ng-click="cancelEditScore($index)"
                 >
                     Cancel
                 </button>

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -14,34 +14,34 @@
     <p>Showing {{scores.length}} scores.</p>
     <table class="table table-bordered table-striped">
         <thead>
-            <tr class="clickable">
+            <tr class="clickable sortable">
                 <th class="span1" ng-click="doSort('index',true)">
-                    <span style="float: left"># </span>
-                    <i style="float: right" class="material-icons">{{sortIcon('index')}}</i>
+                    <span ># </span>
+                    <i  class="material-icons">{{sortIcon('index')}}</i>
                 </th>
                 <th class="span3" ng-click="doSort(['stage.index','-index'],false)">
-                    <span style="float: left">Stage </span>
-                    <i style="float: right" class="material-icons">{{sortIcon(['stage.index','-index'])}}</i>
+                    <span >Stage </span>
+                    <i class="material-icons">{{sortIcon(['stage.index','-index'])}}</i>
                 </th>
                 <th class="span2" ng-click="doSort(['stage.index','round','-index'],false)">
-                    <span style="float: left">Round </span>
-                    <i style="float: right" class="material-icons">{{sortIcon(['stage.index','round','-index'])}}</i>
+                    <span >Round </span>
+                    <i class="material-icons">{{sortIcon(['stage.index','round','-index'])}}</i>
                 </th>
                 <th class="span2" ng-click="doSort('table',false)">
-                    <span style="float: left">Table </span>
-                    <i style="float: right" class="material-icons">{{sortIcon('table')}}</i>
+                    <span >Table </span>
+                    <i class="material-icons">{{sortIcon('table')}}</i>
                 </th>
                 <th class="span2" ng-click="doSort('team.number',false)">
-                    <span style="float: left">Team </span>
-                    <i style="float: right" class="material-icons">{{sortIcon('team.number')}}</i>
+                    <span >Team </span>
+                    <i class="material-icons">{{sortIcon('team.number')}}</i>
                 </th>
                 <th class="span2" ng-click="doSort('team.name',false)">
-                    <span style="float: left">Name </span>
-                    <i style="float: right" class="material-icons">{{sortIcon('team.name')}}</i>
+                    <span >Name </span>
+                    <i class="material-icons">{{sortIcon('team.name')}}</i>
                 </th>
                 <th class="span2" ng-click="doSort('score',true)">
-                    <span style="float: left">Score </span>
-                    <i style="float: right" class="material-icons">{{sortIcon('score')}}</i>
+                    <span >Score </span>
+                    <i class="material-icons">{{sortIcon('score')}}</i>
                 </th>
                 <th>Action</th>
             </tr>


### PR DESCRIPTION
The index filter is currently broken, so I had to remove it from those two pages for the tables to even contain something besides the headers. When it's fixed the ng-repeat should be changed accordingly.
As a result of that, sorting by index in scores.html does nothing.

Solves #249 , #241 

Sorry, multiple forks are confusing.
