### PR TITLE
Seamless scores refresh

### DIFF
--- a/spec/mocks/scoresMock.js
+++ b/spec/mocks/scoresMock.js
@@ -2,10 +2,20 @@ function createScoresMock($q,scoreboard) {
     scoreboard = scoreboard || {};
     return {
         scores: [{
+            stageId: "qualifing",
+            round: 2,
+            teamNumber: 10,
+            table: "table 1",
             score: 1,
+            published: false,
             index: 0
         },{
+            stageId: "final",
+            round: 1,
+            teamNumber: 20,
+            table: "table 2",
             score: 2,
+            published: false,
             index: 1
         }],
         scoreboard: scoreboard,

--- a/spec/mocks/scoresMock.js
+++ b/spec/mocks/scoresMock.js
@@ -2,7 +2,7 @@ function createScoresMock($q,scoreboard) {
     scoreboard = scoreboard || {};
     return {
         scores: [{
-            stageId: "qualifing",
+            stageId: "qualifying",
             round: 2,
             teamNumber: 10,
             table: "table 1",

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -71,22 +71,6 @@ describe('scores', function() {
         });
     });
 
-    describe('publishScore',function() {
-        it('should publish a score and save it',function() {
-            $scope.publishScore(0);
-            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: true});
-            expect(scoresMock.save).toHaveBeenCalled();
-        });
-    });
-
-    describe('unpublishScore',function() {
-        it('should unpublish a score and save it',function() {
-            $scope.unpublishScore(0);
-            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: false});
-            expect(scoresMock.save).toHaveBeenCalled();
-        });
-    });
-
     describe('finishEditScore',function() {
         it('should call update and save',function() {
             $scope.editScore(0);
@@ -107,6 +91,22 @@ describe('scores', function() {
             $scope.editScore(0);
             $scope.cancelEditScore();
             expect(scoresMock._update).toHaveBeenCalled();
+        });
+    });
+
+    describe('publishScore',function() {
+        it('should publish a score and save it',function() {
+            $scope.publishScore(0);
+            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: true});
+            expect(scoresMock.save).toHaveBeenCalled();
+        });
+    });
+
+    describe('unpublishScore',function() {
+        it('should unpublish a score and save it',function() {
+            $scope.unpublishScore(0);
+            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: false});
+            expect(scoresMock.save).toHaveBeenCalled();
         });
     });
 

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -5,6 +5,7 @@ describe('scores', function() {
     });
 
     var $scope, controller, scoresMock, teamsMock, stagesMock,$window,$q;
+    var originalMockScores;
 
     beforeEach(function() {
         angular.mock.module(module.name);
@@ -21,6 +22,7 @@ describe('scores', function() {
                 '$teams': teamsMock,
                 '$stages': stagesMock,
             });
+            originalMockScores = angular.copy(scoresMock.scores);
         });
         $window.alert = jasmine.createSpy('alertSpy');
     });
@@ -97,7 +99,9 @@ describe('scores', function() {
     describe('publishScore',function() {
         it('should publish a score and save it',function() {
             $scope.publishScore(0);
-            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: true});
+            var expectedScore = angular.copy(originalMockScores[0]);
+            expectedScore.published = true;
+            expect(scoresMock.update).toHaveBeenCalledWith(0, expectedScore);
             expect(scoresMock.save).toHaveBeenCalled();
         });
     });
@@ -105,7 +109,7 @@ describe('scores', function() {
     describe('unpublishScore',function() {
         it('should unpublish a score and save it',function() {
             $scope.unpublishScore(0);
-            expect(scoresMock.update).toHaveBeenCalledWith(0, {score: 1, index: 0, published: false});
+            expect(scoresMock.update).toHaveBeenCalledWith(0, originalMockScores[0]);
             expect(scoresMock.save).toHaveBeenCalled();
         });
     });

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -16,10 +16,58 @@ define('views/scores',[
             $scope.scores = $scores.scores;
             $scope.stages = $stages.stages;
 
+            $scope.editing = {}; // Keep state of currently-editing scores
+            $scope.original = {}; // Keep original score when edit started
+
+            var editableProperties = ["stageId", "round", "table", "teamNumber", "score", "published"];
+
+            /**
+             * Pick only the properties of a score that we need while editing
+             * and for determining whether a score is modified (on the server)
+             * while we were editing it (i.e. to cancel the edit if needed).
+             * @param score A single score object from ng-scores
+             * @return A new object with only properties specified in `editableProperties`
+             *         copied from `score`
+             */
+            function scoreToEditState(score) {
+                // Note that we don't use e.g. angular.copy(), because scores
+                // may have subtle changes in sub-objects (e.g. $$-stuff in a
+                // stage), that we don't care about for checking whether we want
+                // to cancel the edit.
+                // Also, scores are often 'polluted' with an extra `index`
+                // property, which typically doesn't exist yet on 'fresh' scores
+                // from the server.
+                var editState = {};
+                editableProperties.forEach(function (prop) {
+                    editState[prop] = score[prop];
+                });
+                return editState;
+            }
+
+            // Watch for new scores. If they change, keep any edit mode
+            // as long as the score didn't change since the edit was started.
+            // Otherwise, cancel the edit.
+            $scope.$watch("scores", function (newScores) {
+                var indexes = Object.keys($scope.editing);
+                indexes.forEach(function(index) {
+                    // Cancel edit mode if the new server value is different
+                    // than what we had before we started editing.
+                    // Note that this also cancels the edit when the item is
+                    // now deleted.
+                    var ourOriginal = $scope.original[index];
+                    var newScore = scoreToEditState(newScores[index]);
+                    if (!angular.equals(ourOriginal, newScore)) {
+                        delete $scope.editing[index];
+                        delete $scope.original[index];
+                    }
+                });
+            }, true);
+
             $scope.doSort = function(col, defaultSort) {
                 $scope.rev = (String($scope.sort) === String(col)) ? !$scope.rev : !!defaultSort;
                 $scope.sort = col;
             };
+
             $scope.removeScore = function(index) {
                 $scores.remove(index);
                 return $scores.save();
@@ -27,20 +75,28 @@ define('views/scores',[
 
             $scope.editScore = function(index) {
                 var score = $scores.scores[index];
-                score.$editing = true;
+                // Create two copies of the score: one to store the unsaved edit,
+                // and another one to compare whether a new version of the
+                // server scores changed compare to what we have.
+                $scope.editing[index] = angular.copy(score);
+                $scope.original[index] = scoreToEditState(score);
             };
 
-            $scope.finishEditScore = function (index) {
-                // The score entry is edited 'inline', then used to
-                // replace the entry in the scores list and its storage.
-                // Because scores are always 'sanitized' before storing,
-                // the $editing flag is automatically discarded.
-                var score = $scores.scores[index];
-                saveScore(score);
+            $scope.finishEditScore = function(index) {
+                // Merge our edit state back into the current
+                // score entry (in case the entry was recently
+                // updated on the server).
+                // Prevents accidentally 'resetting' a property
+                // that isn't listed in scoreToEditState().
+                var merged = angular.extend({}, $scores.scores[index], $scope.editing[index]);
+                delete $scope.editing[index];
+                delete $scope.original[index];
+                saveScore(merged);
             };
 
-            $scope.cancelEditScore = function () {
-                $scores._update();
+            $scope.cancelEditScore = function(index) {
+                delete $scope.editing[index];
+                delete $scope.original[index];
             };
 
             $scope.publishScore = function(index) {

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -24,9 +24,23 @@ define('views/scores',[
                 $scores.remove(index);
                 return $scores.save();
             };
+
             $scope.editScore = function(index) {
                 var score = $scores.scores[index];
                 score.$editing = true;
+            };
+
+            $scope.finishEditScore = function (index) {
+                // The score entry is edited 'inline', then used to
+                // replace the entry in the scores list and its storage.
+                // Because scores are always 'sanitized' before storing,
+                // the $editing flag is automatically discarded.
+                var score = $scores.scores[index];
+                saveScore(score);
+            };
+
+            $scope.cancelEditScore = function () {
+                $scores._update();
             };
 
             $scope.publishScore = function(index) {
@@ -41,15 +55,6 @@ define('views/scores',[
                 saveScore(score);
             };
 
-            $scope.finishEditScore = function(index) {
-                // The score entry is edited 'inline', then used to
-                // replace the entry in the scores list and its storage.
-                // Because scores are always 'sanitized' before storing,
-                // the $editing flag is automatically discarded.
-                var score = $scores.scores[index];
-                saveScore(score);
-            };
-
             function saveScore(score) {
                 try {
                     $scores.update(score.index, score);
@@ -58,10 +63,6 @@ define('views/scores',[
                     $window.alert("Error updating score: " + e);
                 }
             }
-
-            $scope.cancelEditScore = function() {
-                $scores._update();
-            };
 
             $scope.pollSheets = function() {
                 return $scores.pollSheets().catch(function(err) {

--- a/src/js/views/scores.js
+++ b/src/js/views/scores.js
@@ -57,8 +57,7 @@ define('views/scores',[
                     var ourOriginal = $scope.original[index];
                     var newScore = scoreToEditState(newScores[index]);
                     if (!angular.equals(ourOriginal, newScore)) {
-                        delete $scope.editing[index];
-                        delete $scope.original[index];
+                        $scope.cancelEditScore(index);
                     }
                 });
             }, true);

--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -29,47 +29,47 @@
             <td>{{score.index + 1}}</td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownStageError'" title="{{score.error.message}}">error</i>
-                <span ng-if="!score.$editing">
+                <span ng-if="!editing[score.index]">
                     {{score.stage.name}}
                 </span>
-                <span ng-if="score.$editing">
-                    <select ng-model="score.stageId" ng-options="stage.id as stage.name for stage in stages" style="width: 130px"></select>
+                <span ng-if="editing[score.index]">
+                    <select ng-model="editing[score.index].stageId" ng-options="stage.id as stage.name for stage in stages" style="width: 130px"></select>
                 </span>
             </td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownRoundError'" title="{{score.error.message}}">error</i>
-                <span ng-if="!score.$editing">
+                <span ng-if="!editing[score.index]">
                     {{score.round}}
                 </span>
-                <span ng-if="score.$editing">
-                    <input style="width:50px" type="text" ng-model="score.round">
+                <span ng-if="editing[score.index]">
+                    <input style="width:50px" type="text" ng-model="editing[score.index].round">
                 </span>
             </td>
             <td>
-                <span ng-if="!score.$editing">
+                <span ng-if="!editing[score.index]">
                     {{score.table}}
                 </span>
-                <span ng-if="score.$editing">
-                    <input style="width:50px" type="text" ng-model="score.table">
+                <span ng-if="editing[score.index]">
+                    <input style="width:50px" type="text" ng-model="editing[score.index].table">
                 </span>
             </td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownTeamError'" title="{{score.error.message}}">error</i>
-                <span ng-if="!score.$editing">
+                <span ng-if="!editing[score.index]">
                     {{score.team.number}}
                 </span>
-                <span ng-if="score.$editing">
-                    <input style="width:50px" type="text" ng-model="score.teamNumber">
+                <span ng-if="editing[score.index]">
+                    <input style="width:50px" type="text" ng-model="editing[score.index].teamNumber">
                 </span>
             </td>
             <td>{{score.team.name}}</td>
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'InvalidScoreError'" title="{{score.error.message}}">error</i>
-                <span ng-if="!score.$editing">
+                <span ng-if="!editing[score.index]">
                     {{score.score}}
                 </span>
-                <span ng-if="score.$editing">
-                    <input style="width:50px" type="text" ng-model="score.score">
+                <span ng-if="editing[score.index]">
+                    <input style="width:50px" type="text" ng-model="editing[score.index].score">
                 </span>
                 <i class="material-icons" ng-show="score.error.name == 'DuplicateScoreError'" title="{{score.error.message}}">error</i>
             </td>
@@ -87,27 +87,27 @@
                     Unpublish
                 </button>
                 <button class="btn btn-default"
-                    ng-if="!score.$editing"
+                    ng-if="!editing[score.index]"
                     ng-click="editScore(score.index)"
                 >
                     <i class="material-icons">mode_edit</i>
                     Edit
                 </button>
                 <button class="btn btn-default"
-                    ng-if="score.$editing"
+                    ng-if="editing[score.index]"
                     ng-click="finishEditScore(score.index)"
                 >
                     <i class="material-icons">mode_edit</i>
                     Save
                 </button>
                 <button class="btn btn-danger"
-                    ng-if="!score.$editing"
+                    ng-if="!editing[score.index]"
                     fll-really-message="Are you sure you want to completely remove score {{score.score}} for round {{score.match.round}} of team {{score.team.name}}?" fll-really-click="removeScore(score.index)">
                     <i class="material-icons">delete</i>
                     Delete
                 </button>
                 <button class="btn btn-default"
-                    ng-if="score.$editing"
+                    ng-if="editing[score.index]"
                     ng-click="cancelEditScore(score.index)"
                 >
                     Cancel


### PR DESCRIPTION
This is one part of getting to #245: getting rid of the manual Refresh button actions.

This PR solves one of the original reasons for having that button (instead of having e.g. a timer / message refresh it in the background). The problem was that whenever the scores.json was reloaded from the server, any in-progress edits would be 'reverted'.

Now, edits can be made while scores.json is reloaded from server.
An edit will be cancelled whenever the server version also changed the score that's being edited (or it was removed).

Note that this doesn't yet solve other aspects (e.g. automatically refreshing, non-atomic merges on the server, etc.). This was already the case, and is a subject for further PRs.