### PR TITLE
scores: Always show the team number, even if that team doesn't exist.

### DIFF
--- a/src/views/pages/scores.html
+++ b/src/views/pages/scores.html
@@ -56,7 +56,7 @@
             <td>
                 <i class="material-icons" ng-show="score.error.name == 'UnknownTeamError'" title="{{score.error.message}}">error</i>
                 <span ng-if="!score.$editing">
-                    {{score.team.number}}
+                    {{score.teamNumber}}
                 </span>
                 <span ng-if="score.$editing">
                     <input style="width:50px" type="text" ng-model="score.teamNumber">


### PR DESCRIPTION
When a score entry contains a team number that doesn't exist, that team number is not shown in the overview. This fixes that.

To reproduce: edit a score entry, change its team number to a non-existing one.