### PR TITLE
Refactor scores

### DIFF
--- a/spec/mocks/scoresMock.js
+++ b/spec/mocks/scoresMock.js
@@ -25,8 +25,6 @@ function createScoresMock($q,scoreboard) {
         update: jasmine.createSpy('scoreUpdateSpy'),
         _update: jasmine.createSpy('score_UpdateSpy'),
         save: jasmine.createSpy('scoreSaveSpy'),
-        getRankings: jasmine.createSpy('getRankings').and.returnValue({
-            scoreboard: scoreboard
-        })
+        getRankings: jasmine.createSpy('getRankings').and.returnValue(scoreboard),
     };
 }

--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -392,9 +392,10 @@ describe('ng-scores',function() {
                 { team: team1, stage: mockStage, round: 1, score: 10 },
                 { team: team1, stage: mockStage, round: 1, score: 20 },
             ], true);
+            expect($scores.validationErrors.length).toBe(2);
+            expect($scores.scores[0].error).toEqual(jasmine.any($scores.DuplicateScoreError));
             expect($scores.scores[1].error).toEqual(jasmine.any($scores.DuplicateScoreError));
             expect(board["test"][0].highest).toEqual(10);
-            expect($scores.validationErrors.length).toBeGreaterThan(0);
         });
 
         it("should ignore but warn about invalid team", function() {

--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -340,10 +340,10 @@ describe('ng-scores',function() {
                 { team: team3, stage: mockStage, round: 2, score: 0 },
                 { team: team3, stage: mockStage, round: 3, score: 20 },
             ]);
-            var filtered = $scores.getRankings({
+            var scoreboard = $scores.getRankings({
                 "test": 2
             });
-            var result = filtered.scoreboard["test"].map(function(entry) {
+            var result = scoreboard["test"].map(function(entry) {
                 return {
                     rank: entry.rank,
                     teamNumber: entry.team.number,

--- a/src/js/controllers/ExportRankingDialogController.js
+++ b/src/js/controllers/ExportRankingDialogController.js
@@ -35,7 +35,7 @@ define('controllers/ExportRankingDialogController',[
                 $scope.export.rounds = Array.apply(null, Array(params.round)).map(function (_, i) {return i+1;});
                 var stageFilter = {};
                 stageFilter[params.stage.id] = params.round;
-                $scope.filterscoreboard = $scores.getRankings(stageFilter).scoreboard;
+                $scope.filterscoreboard = $scores.getRankings(stageFilter);
 
                 $timeout(function () {
                     var htmloutput = "<!DOCTYPE html><html><head><title>"+ params.stage.name + " " + params.round + "</title></head><body id=\"bodyranking\">";

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -483,13 +483,11 @@ define('services/ng-scores',[
                 board[stage] = [];
             });
 
-            // Walk all scores, and put them in the corresponding round of each stage.
-            // This also performs sanity checks on the scores, marking failures.
-            // Highest scores and rankings are computed later.
-            this._rawScores.forEach(function(_score) {
-                // Create a copy of the score, such that we can add
-                // additional info
-                var s = {
+            // Create a copy of the score, such that we can add
+            // additional info (e.g. validation errors) without
+            // polluting rawScores.
+            results.scores = this._rawScores.map(function (_score) {
+                return {
                     file: _score.file,
                     teamNumber: _score.teamNumber,
                     team: $teams.get(_score.teamNumber),
@@ -504,8 +502,10 @@ define('services/ng-scores',[
                     modified: false,
                     error: null
                 };
-                results.scores.push(s);
+            });
 
+            // Walk all scores and annotate with sanity checks
+            results.scores.forEach(function (s) {
                 // Mark score as modified if there have been changes to the
                 // original entry
                 if (s.score !== s.originalScore) {

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -513,9 +513,9 @@ define('services/ng-scores',[
                 }
 
                 // Check whether score is for a 'known' stage
-                var bstage = board[_score.stageId];
+                var bstage = board[s.stageId];
                 if (!bstage) {
-                    s.error = new UnknownStageError(_score.stageId);
+                    s.error = new UnknownStageError(s.stageId);
                     return;
                 }
 
@@ -541,7 +541,7 @@ define('services/ng-scores',[
 
                 // Check whether team is valid
                 if (!s.team) {
-                    s.error = new UnknownTeamError(_score.teamNumber);
+                    s.error = new UnknownTeamError(s.teamNumber);
                     return;
                 }
 

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -513,8 +513,7 @@ define('services/ng-scores',[
                 }
 
                 // Check whether score is for a 'known' stage
-                var bstage = board[s.stageId];
-                if (!bstage) {
+                if (!s.stage) {
                     s.error = new UnknownStageError(s.stageId);
                     return;
                 }
@@ -553,6 +552,7 @@ define('services/ng-scores',[
                 // Find existing entry for this team, or create one
                 var bteam;
                 var i;
+                var bstage = board[s.stageId];
                 for (i = 0; i < bstage.length; i++) {
                     if (bstage[i].team.number === s.team.number) {
                         bteam = bstage[i];

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -444,22 +444,10 @@ define('services/ng-scores',[
         };
 
         /**
-         * Compute scoreboard and sanitized/validated scores.
-         *
-         * Optionally, pass an object containing stageId => nrOfRoundsOrTrue mapping.
-         * E.g. { "practice": true, "qualifying": 2 }, which computes the ranking
-         * for all rounds in the practice stage, and the first 2 rounds of the
-         * qualifying stage.
-         *
-         * Resulting object contains `scores` and `scoreboard` properties.
-         * If no stages filter is passed, all scores will be output.
-         * If a stages filter is passed, only valid and relevant scores are
-         * output.
-         *
-         * @param  stages Optional object stageId => nrOfRoundsOrTrue
-         * @return Results object with validated scores and per-stage rankings
+         * Perform validation on scores.
+         * @return list of scores including annotations about e.g. errors
          */
-        Scores.prototype.getRankings = function(stages) {
+        Scores.prototype.getValidatedScores = function() {
             // Create a copy of the score, such that we can add
             // additional info (e.g. validation errors) without
             // polluting rawScores.
@@ -551,6 +539,28 @@ define('services/ng-scores',[
                     teamEntries[s.round] = s;
                 }
             });
+
+            return validatedScores;
+        }
+
+        /**
+         * Compute scoreboard and sanitized/validated scores.
+         *
+         * Optionally, pass an object containing stageId => nrOfRoundsOrTrue mapping.
+         * E.g. { "practice": true, "qualifying": 2 }, which computes the ranking
+         * for all rounds in the practice stage, and the first 2 rounds of the
+         * qualifying stage.
+         *
+         * Resulting object contains `scores` and `scoreboard` properties.
+         * If no stages filter is passed, all scores will be output.
+         * If a stages filter is passed, only valid and relevant scores are
+         * output.
+         *
+         * @param  stages Optional object stageId => nrOfRoundsOrTrue
+         * @return Results object with validated scores and per-stage rankings
+         */
+        Scores.prototype.getRankings = function(stages) {
+            var validatedScores = this.getValidatedScores();
 
             // Create a pass-all filter if necessary
             var haveFilter = !!stages;


### PR DESCRIPTION
Another step towards #245.

This splits score validation and ranking into individual pieces, which is necessary in order to more easily split it off into code that can be used on both the server and client.

It has no functional changes.
In fact, the tests kept running at each commit except f4497c3 (which I thought was more readable to split off).
This should make it easier to follow the moves with each commit.

Note that the refactoring is not complete yet, but it's big enough already.