### PR TITLE
Simplify ranking

### DIFF
--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -395,7 +395,6 @@ describe('ng-scores',function() {
             expect($scores.validationErrors.length).toBe(2);
             expect($scores.scores[0].error).toEqual(jasmine.any($scores.DuplicateScoreError));
             expect($scores.scores[1].error).toEqual(jasmine.any($scores.DuplicateScoreError));
-            expect(board["test"][0].highest).toEqual(10);
         });
 
         it("should ignore but warn about invalid team", function() {

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -558,16 +558,16 @@ define('services/ng-scores',[
          * Resulting object is a per-stage array containing one item per team,
          * which lists the rank, team info, scores per round and highest score.
          *
-         * @param  stages Optional object stageId => nrOfRoundsOrTrue
+         * @param  stageFilter Optional object stageId => nrOfRoundsOrTrue
          * @return Per-stage rankings
          */
-        Scores.prototype.getRankings = function(stages) {
+        Scores.prototype.getRankings = function(stageFilter) {
             // Create a pass-all filter if necessary
-            var haveFilter = !!stages;
-            if (!stages) {
-                stages = {};
+            var haveFilter = !!stageFilter;
+            if (!stageFilter) {
+                stageFilter = {};
                 $stages.stages.forEach(function (stage) {
-                    stages[stage.id] = true;
+                    stageFilter[stage.id] = true;
                 });
             }
 
@@ -575,9 +575,9 @@ define('services/ng-scores',[
             // e.g. `true` is passed)
             // And create empty lists for each stage
             var board = {};
-            Object.keys(stages).forEach(function (stage) {
-                var s = stages[stage];
-                stages[stage] = typeof s === "number" && s || s && Infinity || 0;
+            Object.keys(stageFilter).forEach(function (stage) {
+                var s = stageFilter[stage];
+                stageFilter[stage] = typeof s === "number" && s || s && Infinity || 0;
                 board[stage] = [];
             });
 
@@ -588,7 +588,7 @@ define('services/ng-scores',[
                 }
 
                 // Ignore score if filtered
-                if (haveFilter && s.round > stages[s.stageId]) {
+                if (haveFilter && s.round > stageFilter[s.stageId]) {
                     return false;
                 }
 
@@ -609,7 +609,7 @@ define('services/ng-scores',[
                     }
                 }
                 if (!bteam) {
-                    var maxRounds = Math.min(s.stage.rounds, stages[s.stageId]);
+                    var maxRounds = Math.min(s.stage.rounds, stageFilter[s.stageId]);
                     var initialScores = new Array(maxRounds);
                     var initialEntries = new Array(maxRounds);
                     for (i = 0; i < maxRounds; i++) {

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -60,14 +60,13 @@ define('services/ng-scores',[
         }
 
         function DuplicateScoreError(score) {
-            this.score = score;
             this.team = score.team;
             this.stage = score.stage;
             this.round = score.round;
             this.name = "DuplicateScoreError";
             this.message = format(
                 "duplicate score for team '{0}' ({1}), stage {2}, round {3}",
-                this.team.name, this.score.teamNumber,
+                this.team.name, score.teamNumber,
                 this.stage.name, this.round
             );
         }

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -563,7 +563,6 @@ define('services/ng-scores',[
          */
         Scores.prototype.getRankings = function(stageFilter) {
             // Create a pass-all filter if necessary
-            var haveFilter = !!stageFilter;
             if (!stageFilter) {
                 stageFilter = {};
                 $stages.stages.forEach(function (stage) {
@@ -588,7 +587,7 @@ define('services/ng-scores',[
                 }
 
                 // Ignore score if filtered
-                if (haveFilter && s.round > stageFilter[s.stageId]) {
+                if (s.round > stageFilter[s.stageId]) {
                     return false;
                 }
 

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -582,11 +582,8 @@ define('services/ng-scores',[
             });
 
             // Create filtered scores (both user-supplied filter and errors).
-            // Ignore scores with errors, except if it's a duplicate
-            // (i.e. keep the first score in the list, to prevent it
-            // from disappearing due to a later error).
             var filteredScores = this.scores.filter(function (s) {
-                if (s.error && !(s.error instanceof DuplicateScoreError && s.error.score === s)) {
+                if (s.error) {
                     return false;
                 }
 


### PR DESCRIPTION
Part of #245 to prepare for making ranking computation independent of validation results.

The current ranking computation includes a special case where it does allow the first duplicate score to be included into rankings.

This was from before we had the possibility of having 'published' scores, where we didn't want a (most likely) scrutinized (checked) score to disappear due to a later (yet unchecked score) which contained a mistake.

We will switch to published scores only, which means this check is no longer necessary, and in fact makes the ranking computation independent of the scores validation.

Additionally, a small rename and removal of a redundant variable.