### PR TITLE
Ranking only published scores

### DIFF
--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -231,6 +231,30 @@ describe('ng-scores',function() {
         });
     });
 
+    describe('isValidScore', function () {
+        it('should accept valid scores', function () {
+            expect($scores.isValidScore(0)).toBe(true);
+            expect($scores.isValidScore(-1)).toBe(true);
+            expect($scores.isValidScore(1000)).toBe(true);
+            expect($scores.isValidScore("dnc")).toBe(true); // Did Not Compete
+            expect($scores.isValidScore("dsq")).toBe(true); // DiSQualified
+        });
+
+        it('should reject invalid scores', function () {
+            expect($scores.isValidScore(undefined)).toBe(false);
+            expect($scores.isValidScore(null)).toBe(false);
+            expect($scores.isValidScore(NaN)).toBe(false);
+            expect($scores.isValidScore(Infinity)).toBe(false);
+            expect($scores.isValidScore(-Infinity)).toBe(false);
+            expect($scores.isValidScore("dnq")).toBe(false);
+            expect($scores.isValidScore("foo")).toBe(false);
+            expect($scores.isValidScore(true)).toBe(false);
+            expect($scores.isValidScore(false)).toBe(false);
+            expect($scores.isValidScore({})).toBe(false);
+            expect($scores.isValidScore([])).toBe(false);
+        });
+    });
+
     describe('scoreboard', function() {
         var board;
         beforeEach(function() {

--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -264,6 +264,7 @@ describe('ng-scores',function() {
             $scores.beginupdate();
             $scores.clear();
             input.map(function(score) {
+                score.published = true;
                 $scores.add(score);
             });
             $scores.endupdate();
@@ -383,7 +384,7 @@ describe('ng-scores',function() {
             ]);
         });
 
-        it("should ignore but warn about scores for unknown rounds / stages", function() {
+        it("should include but warn about scores for unknown rounds / stages", function() {
             fillScores([
                 { team: team1, stage: { id: "foo" }, round: 1, score: 0 },
                 { team: team1, stage: mockStage, round: 0, score: 0 },
@@ -392,7 +393,7 @@ describe('ng-scores',function() {
             expect($scores.scores[0].error).toEqual(jasmine.any($scores.UnknownStageError));
             expect($scores.scores[1].error).toEqual(jasmine.any($scores.UnknownRoundError));
             expect($scores.scores[2].error).toEqual(jasmine.any($scores.UnknownRoundError));
-            expect(board["test"].length).toEqual(0);
+            expect(board["test"].length).toEqual(1);
             expect($scores.validationErrors.length).toEqual(3);
         });
 
@@ -411,7 +412,7 @@ describe('ng-scores',function() {
             expect($scores.validationErrors.length).toEqual(5);
         });
 
-        it("should ignore but warn about duplicate score", function() {
+        it("should include but warn about duplicate score", function() {
             fillScores([
                 { team: team1, stage: mockStage, round: 1, score: 10 },
                 { team: team1, stage: mockStage, round: 1, score: 20 },
@@ -419,6 +420,8 @@ describe('ng-scores',function() {
             expect($scores.validationErrors.length).toBe(2);
             expect($scores.scores[0].error).toEqual(jasmine.any($scores.DuplicateScoreError));
             expect($scores.scores[1].error).toEqual(jasmine.any($scores.DuplicateScoreError));
+            // Last score will overwrite any previous entry
+            expect(board["test"][0].highest).toEqual(20);
         });
 
         it("should ignore but warn about invalid team", function() {

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -572,6 +572,8 @@ define('services/ng-scores',[
          * @return Per-stage rankings
          */
         Scores.prototype.getRankings = function(stageFilter) {
+            var self = this;
+
             // Create a pass-all filter if necessary
             if (!stageFilter) {
                 stageFilter = {};
@@ -592,12 +594,18 @@ define('services/ng-scores',[
 
             // Create filtered scores (both user-supplied filter and errors).
             var filteredScores = this.scores.filter(function (s) {
-                if (s.error) {
+                // Only include published scores
+                if (!s.published) {
+                    return false;
+                }
+
+                // Ignore completely invalid scores
+                if (!self.isValidScore(s.score)) {
                     return false;
                 }
 
                 // Ignore score if filtered
-                if (s.round > stageFilter[s.stageId]) {
+                if (!stageFilter[s.stageId] || s.round > stageFilter[s.stageId]) {
                     return false;
                 }
 

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -231,10 +231,23 @@ define('services/ng-scores',[
         };
 
         /**
+         * Determine whether given score is valid, i.e. a number, or "dnc" (Did Not Compete),
+         * or "dsq" (DiSQualified).
+         * Note: `null` and `undefined` are invalid: remove the score to denote this instead.
+         *
+         * @param score {any} Score value to test
+         * @return true when score is valid
+         */
+        Scores.prototype.isValidScore = function (score) {
+            return typeof score === "number" && score > -Infinity && score < Infinity ||
+                score === "dnc" || score === "dsq";
+        };
+
+        /**
          * Convert 'dirty' score value to correct type used during score
          * computations etc.
          * Valid inputs are fixed strings like "dnc" (Did Not Compete) and
-         * "dnq" (Did Not Qualify) in any combination of upper/lower case,
+         * "dsq" (DiSQualified) in any combination of upper/lower case,
          * null (dummy entry, maybe because score was removed) and numbers
          * (also as strings). Empty string is converted to null.
          * Invalid input is simply returned (and later marked as invalid
@@ -448,6 +461,8 @@ define('services/ng-scores',[
          * @return list of scores including annotations about e.g. errors
          */
         Scores.prototype.getValidatedScores = function() {
+            var self = this;
+
             // Create a copy of the score, such that we can add
             // additional info (e.g. validation errors) without
             // polluting rawScores.
@@ -498,11 +513,7 @@ define('services/ng-scores',[
                 // mean that one could 'reset' a team's score for that round.
                 // If a team did not play in a round, there will simply be no
                 // entry in scores.
-                if (!(
-                    typeof s.score === "number" && s.score > -Infinity && s.score < Infinity ||
-                    s.score === "dnc" ||
-                    s.score === "dsq"
-                )) {
+                if (!self.isValidScore(s.score)) {
                     s.error = new InvalidScoreError(s.score);
                     return;
                 }


### PR DESCRIPTION
Part of #245.

This switches the ranking to include only published scores.
Tests were updated accordingly.

Note: there are two 'strange' changes: removal of check for DuplicateScoreError and removal of haveFilter condition. Both of these are also already removed (and explained) in #286, so can be ignored for this PR.
If #286 is merged first, I can fixup this PR to get rid of these two changes, if needed.