### PR TITLE
Filesystem hooks mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2491,6 +2491,17 @@
         }
       }
     },
+    "jasmine": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.0.6",
+        "jasmine-core": "2.8.0"
+      }
+    },
     "jasmine-core": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3011,6 +3011,12 @@
       "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
       "dev": true
     },
+    "mock-fs": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.4.1.tgz",
+      "integrity": "sha512-C8aapOvl77Bs18WCkejdLuX2kX8DaqaJ7ZmqUmX9U6HD2g31Pd0tZfNBAEVulmJWKyzUIyutrtxiIoNdXLAYsw==",
+      "dev": true
+    },
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "karma-coverage": "^1.1.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
+    "mock-fs": "^4.4.1",
     "phantomjs-prebuilt": "^2.1.7",
     "saxon-stream2": "0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node localserver",
-    "test": "karma start --single-run --browsers Firefox --reporters dots,coverage"
+    "test": "jasmine server_test/*.js && karma start --single-run --browsers Firefox --reporters dots,coverage"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
     "grunt-http-server": "^2.0.0",
     "grunt-karma": "^2.0.0",
     "grunt-nw-builder": "^3.0.0",
+    "jasmine": "^2.8.0",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.1",
     "karma-chrome-launcher": "^2.0.0",

--- a/server_modules/args.js
+++ b/server_modules/args.js
@@ -1,6 +1,8 @@
+var path = require('path');
 var argv = require('minimist')(process.argv.slice(2));
 
 exports.port = argv.p || 1390;
 exports.basicAuthCreds = argv.u;
+exports.rootdir = argv.r || path.resolve(__dirname, "..");
 exports.datadir = argv.d || 'data';
 exports.slaveMode = argv.s || false;

--- a/server_modules/file_system.js
+++ b/server_modules/file_system.js
@@ -25,6 +25,112 @@ exports.resolve = function(file) {
     return path.resolve(args.rootdir, file);
 };
 
+/**
+ * @typedef {Object} Hook
+ * @property {RegExp | string} pattern
+ * @property {(data: string, filename: string) => string | Promise<string>} callback
+ */
+
+/**
+ * Registry of filesystem hooks.
+ * @type {{ [type: string]: Hook[] }}
+ */
+var hooksRegistry;
+
+/**
+ * Clear all register hooks, returns function to restore them.
+ * Useful for testing.
+ */
+exports.clearHooks = function () {
+    var oldHooks = hooksRegistry;
+    hooksRegistry = {
+        write: [],
+    };
+    return () => { hooksRegistry = oldHooks; };
+};
+
+// Initialize hooks
+exports.clearHooks();
+
+/**
+ * Call any hooks of the specified type (e.g. "write"), in order of registration,
+ * when they match the filename. First hook is called with data, subsequent hooks
+ * are called with result of previous hook.
+ * If no hooks match, the data is returned as-is (in a Promise).
+ *
+ * Filename is first made relative to args.rootdir, to make matching independent
+ * of location of this package.
+ *
+ * @param type {string} Type of hook (e.g. "write")
+ * @param filename {string} Filename to match against
+ * @param data {string} Data to be passed to hook
+ * @return {Promise<string>} Transformed data
+ */
+exports.callHooks = function (type, filename, data) {
+    const hooks = hooksRegistry[type];
+    if (!hooks) {
+        throw new Error("unknown hook type " + type);
+    }
+
+    // Make filename a relative path, e.g. "data/scores.json"
+    filename = path.relative(args.rootdir, filename);
+
+    // Start with source data
+    const initial = Promise.resolve(data);
+
+    // Run each hook consecutively
+    return hooks.reduce((intermediate, hook) => {
+        const pattern = hook.pattern;
+        const isMatch = typeof pattern === "string" ? pattern === filename : pattern.test(filename);
+        if (!isMatch) {
+            return intermediate;
+        }
+        // It matches: add another transform to the chain
+        return intermediate.then((data) => {
+            const transformed = hook.callback(data, filename);
+            if (typeof transformed !== "string" && (typeof transformed !== "object" || typeof transformed.then !== "function")) {
+                throw new Error("hook for pattern " + hook.pattern.toString() + " returned invalid data");
+            }
+            return transformed;
+        });
+    }, initial);
+}
+
+/**
+ * Register a hook to be called when operating on a file.
+ *
+ * Usage example:
+ *   registerHook('write', /^foo\.txt$/, (data) => data.toUpperCase());
+ * or
+ *   registerHook('write', 'foo.txt', (data) => data.toUpperCase());
+ *
+ * Then, writeFile('foo.txt', 'something') will write SOMETHING instead.
+ *
+ * Hooks are called in order of registration, and subsequent hooks will
+ * receive the output of the previous hook(s).
+ *
+ * Before matching and calling hooks, any filename is first made relative
+ * to the package's root dir (i.e. `args.rootdir`).
+ *
+ * @param type {string} Type of hook (e.g. "write")
+ * @param pattern {RegExp | string} Matched against filename relative to root dir (e.g. /^data\/scores\.json$/)
+ * @param callback {(data: string, filename: string) => string | Promise<string>}
+ *            Called when pattern matches filename.
+ *            Receives the data to be written (utf-8) and filename, is expected to return (promise for) optionally
+ *            modified file data. It is an error to return nothing.
+ * @return void
+ */
+exports.registerHook = function (type, pattern, callback) {
+    const hooks = hooksRegistry[type];
+    if (!hooks) {
+        throw new Error("unknown hook type " + type);
+    }
+    hooks.push({
+        pattern,
+        callback
+    });
+};
+
 exports.readFile = function(file) {
     file = exports.resolve(file);
 

--- a/server_modules/file_system.js
+++ b/server_modules/file_system.js
@@ -161,7 +161,8 @@ exports.writeFile = function (file, contents) {
     file = exports.resolve(file);
     var dir = path.dirname(file);
     return Q.nfcall(mkdirp, dir)
-        .then(() => Q.nfcall(fs.writeFile, file, contents));
+        .then(() => exports.callHooks("write", file, contents))
+        .then((transformed) => Q.nfcall(fs.writeFile, file, transformed));
 };
 
 exports.readJsonFile = function(file) {

--- a/server_modules/file_system.js
+++ b/server_modules/file_system.js
@@ -22,7 +22,7 @@ exports.getDataFilePath = function(file) {
 };
 
 exports.resolve = function(file) {
-    return path.resolve(path.dirname(process.argv[1]), file);
+    return path.resolve(args.rootdir, file);
 };
 
 exports.readFile = function(file) {

--- a/server_modules/file_system.js
+++ b/server_modules/file_system.js
@@ -72,8 +72,8 @@ exports.callHooks = function (type, filename, data) {
         throw new Error("unknown hook type " + type);
     }
 
-    // Make filename a relative path, e.g. "data/scores.json"
-    filename = path.relative(args.rootdir, filename);
+    // Make filename a relative path with forward slashes, e.g. "data/scores.json"
+    filename = path.relative(args.rootdir, filename).replace(/\\/g, '/');
 
     // Start with source data
     const initial = Promise.resolve(data);

--- a/server_modules/file_system.js
+++ b/server_modules/file_system.js
@@ -51,19 +51,11 @@ exports.readFile = function(file) {
     });
 };
 
-exports.writeFile = function(file, contents) {
+exports.writeFile = function (file, contents) {
     file = exports.resolve(file);
-
-    return Q.promise(function(resolve, reject) {
-        var dir = path.dirname(file);
-        mkdirp(dir, function(err) {
-            if (err) return reject(err);
-            fs.writeFile(file, contents, function(err) {
-                if(err) return reject(err);
-                resolve();
-            });
-        });
-    });
+    var dir = path.dirname(file);
+    return Q.nfcall(mkdirp, dir)
+        .then(() => Q.nfcall(fs.writeFile, file, contents));
 };
 
 exports.readJsonFile = function(file) {

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -3,8 +3,11 @@ const file_system = require("../server_modules/file_system");
 
 describe("file_system", () => {
     describe("resolve", () => {
-        it("should resolve to a path relative to the executable's root", () => {
-            const rootdir = path.dirname(process.argv[1]);
+        it("should resolve to a path relative to the package's root", () => {
+            const packageJson = require.resolve("../package.json");
+            expect(require(packageJson)).toBeTruthy(); // sanity check on the path above
+
+            const rootdir = path.dirname(packageJson);
             expect(file_system.resolve("foo.txt")).toBe(path.resolve(rootdir, "foo.txt"));
         });
     });

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -1,0 +1,11 @@
+const path = require("path");
+const file_system = require("../server_modules/file_system");
+
+describe("file_system", () => {
+    describe("resolve", () => {
+        it("should resolve to a path relative to the executable's root", () => {
+            const rootdir = path.dirname(process.argv[1]);
+            expect(file_system.resolve("foo.txt")).toBe(path.resolve(rootdir, "foo.txt"));
+        });
+    });
+});

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -92,10 +92,18 @@ describe("file_system", () => {
             );
         });
 
-        it("matches against relative paths", async () => {
+        it("matches against POSIX-style relative paths", async () => {
             file_system.registerHook("write", "data/foo.txt", (data) => data.toUpperCase());
             const fullPath = file_system.resolve("data/foo.txt");
+            // Note: fullPath will be '/some/path/data/foo.txt' on Linux, and
+            // e.g. 'C:\some\path\data\foo.txt' on Windows
             const result = await file_system.callHooks("write", fullPath, "something");
+            expect(result).toBe("SOMETHING");
+        });
+
+        it("supports Windows-style paths", async () => {
+            file_system.registerHook("write", "data/bar/foo.txt", (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "data\\bar\\foo.txt", "something");
             expect(result).toBe("SOMETHING");
         });
     });

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -5,6 +5,11 @@ const mockFs = require("mock-fs");
 const file_system = require("../server_modules/file_system");
 
 describe("file_system", () => {
+    // Create empty hooks before tests, then restore original ones after tests
+    let restoreHooks;
+    beforeEach(() => restoreHooks = file_system.clearHooks());
+    afterEach(() => restoreHooks());
+
     afterEach(() => mockFs.restore());
 
     describe("resolve", () => {
@@ -14,6 +19,95 @@ describe("file_system", () => {
 
             const rootdir = path.dirname(packageJson);
             expect(file_system.resolve("foo.txt")).toBe(path.resolve(rootdir, "foo.txt"));
+        });
+    });
+
+    describe("registerHook", () => {
+        it("allows registering hook using string", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHING");
+        });
+
+        it("allows registering hook using regex", async () => {
+            file_system.registerHook("write", /^foo\.txt$/, (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHING");
+        });
+
+        it("throws for unknown hook types", () => {
+            expect(() => file_system.registerHook("foo", "foo.txt", (data) => data)).toThrow();
+        });
+    });
+
+    describe("callHooks", () => {
+        it("returns raw data without hooks", async () => {
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("something");
+        });
+
+        it("matches hooks using string, match", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHING");
+        });
+
+        it("matches hooks using string, no match", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "fooXtxt", "something");
+            expect(result).toBe("something");
+        });
+
+        it("matches hooks using regex, match", async () => {
+            file_system.registerHook("write", /^foo\.txt$/, (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHING");
+        });
+
+        it("matches hooks using regex, no match", async () => {
+            file_system.registerHook("write", /^foo\.txt$/, (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "fooXtxt", "something");
+            expect(result).toBe("something");
+        });
+
+        it("supports synchronous transforms", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => data + data);
+            file_system.registerHook("write", "foo.txt", (data) => data.toUpperCase());
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHINGSOMETHING");
+        });
+
+        it("supports asynchronous transforms", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => Promise.resolve(data + data));
+            file_system.registerHook("write", "foo.txt", (data) => Promise.resolve(data.toUpperCase()));
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("SOMETHINGSOMETHING");
+        });
+
+        it("throws when returning nothing from hook", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => { /* no op */ });
+            await file_system.callHooks("write", "foo.txt", "something").then(
+                () => fail("should throw"),
+                (e) => expect(e instanceof Error).toBe(true)
+            );
+        });
+
+        it("matches against relative paths", async () => {
+            file_system.registerHook("write", "data/foo.txt", (data) => data.toUpperCase());
+            const fullPath = file_system.resolve("data/foo.txt");
+            const result = await file_system.callHooks("write", fullPath, "something");
+            expect(result).toBe("SOMETHING");
+        });
+    });
+
+    describe("clearHooks", () => {
+        it("allows to clear and restore hooks", async () => {
+            file_system.registerHook("write", "foo.txt", () => "abc");
+            const restore = file_system.clearHooks();
+            file_system.registerHook("write", "foo.txt", () => "def");
+            restore();
+            const result = await file_system.callHooks("write", "foo.txt", "something");
+            expect(result).toBe("abc");
         });
     });
 

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -126,5 +126,11 @@ describe("file_system", () => {
             await file_system.writeFile("some/path/foo.txt", "something");
             expect(nodeFs.readFileSync("some/path/foo.txt", "utf8")).toBe("something");
         });
+
+        it("can be hooked", async () => {
+            file_system.registerHook("write", "foo.txt", (data) => data.toUpperCase());
+            await file_system.writeFile("foo.txt", "something");
+            expect(nodeFs.readFileSync("foo.txt", "utf8")).toBe("SOMETHING");
+        });
     });
 });

--- a/server_test/file_systemSpec.js
+++ b/server_test/file_systemSpec.js
@@ -1,7 +1,12 @@
+const nodeFs = require("fs");
 const path = require("path");
+const mockFs = require("mock-fs");
+
 const file_system = require("../server_modules/file_system");
 
 describe("file_system", () => {
+    afterEach(() => mockFs.restore());
+
     describe("resolve", () => {
         it("should resolve to a path relative to the package's root", () => {
             const packageJson = require.resolve("../package.json");
@@ -9,6 +14,23 @@ describe("file_system", () => {
 
             const rootdir = path.dirname(packageJson);
             expect(file_system.resolve("foo.txt")).toBe(path.resolve(rootdir, "foo.txt"));
+        });
+    });
+
+    describe("writeFile", () => {
+        beforeEach(() => {
+            // Create an empty filesystem
+            mockFs({});
+        });
+
+        it("should write a file", async () => {
+            await file_system.writeFile("foo.txt", "something");
+            expect(nodeFs.readFileSync("foo.txt", "utf8")).toBe("something");
+        });
+
+        it("should create full path if it doesn't exist yet", async () => {
+            await file_system.writeFile("some/path/foo.txt", "something");
+            expect(nodeFs.readFileSync("some/path/foo.txt", "utf8")).toBe("something");
         });
     });
 });


### PR DESCRIPTION
Part of #245.

This adds a hooking mechanism to allow transforming data (e.g. scores.json) between receiving it from the browser and actually saving it to disk.

You'll need to run `npm install` due to new dependencies.
Then, run `npm test` to run the tests, which now also include tests for the newly added server code.

Note that actually using the new hooks mechanism is the subject of future PRs.
As such, it should have no noticeable impact on the existing functionality.