### PR TITLE
appveyor: Add support for automatic Windows CI tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  nodejs_version: "8.4"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # Upgrade npm
+  - npm install -g npm
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
The fs_hooks functionality appeared to fail on Windows, whereas some of us only build and test on Linux.
We also had a case the other way around: functionality working on Windows, failing on Linux.

This adds support for AppVeyor ('Travis for Windows').

I also tried to set an account up on AppVeyor such that it automatically builds everything when pushing, but that doesn't seem to work yet. Manually triggered a build of this branch, and that worked though.