### PR TITLE
Fix test dependencies

### DIFF
--- a/spec/controllers/DescriptionDialogControllerSpec.js
+++ b/spec/controllers/DescriptionDialogControllerSpec.js
@@ -1,8 +1,6 @@
 describe('DescriptionDialogController',function() {
 
-    var module = factory('controllers/DescriptionDialogController',{
-        // 'services/log': logMock,
-    });
+    var module = factory('controllers/DescriptionDialogController');
 
     var $scope, controller, handshakeMock;
 

--- a/spec/controllers/DescriptionDialogControllerSpec.js
+++ b/spec/controllers/DescriptionDialogControllerSpec.js
@@ -1,10 +1,10 @@
 describe('DescriptionDialogController',function() {
 
-    var module = factory('controllers/DescriptionDialogController');
-
+    var module;
     var $scope, controller, handshakeMock;
 
     beforeEach(function() {
+        module = factory('controllers/DescriptionDialogController');
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/controllers/ExportRankingDialiogControllerSpec.js
+++ b/spec/controllers/ExportRankingDialiogControllerSpec.js
@@ -1,16 +1,16 @@
 describe('ExportRankingDialogController',function() {
 
-    var module = factory('controllers/ExportRankingDialogController',{
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scope, $timeout, stagesMock, scoresMock, handshakeMock;
     var fakeScoreboard = {
         "1": [1,2,3,4]
     };
 
     beforeEach(function() {
+        module = factory('controllers/ExportRankingDialogController',{
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q,_$timeout_) {
             $scope = $rootScope.$new();

--- a/spec/controllers/ExportRankingDialiogControllerSpec.js
+++ b/spec/controllers/ExportRankingDialiogControllerSpec.js
@@ -2,6 +2,7 @@ describe('ExportRankingDialogController',function() {
 
     var module = factory('controllers/ExportRankingDialogController',{
         'services/log': logMock,
+        'services/fs': {},
     });
 
     var $scope, $timeout, stagesMock, scoresMock, handshakeMock;

--- a/spec/controllers/NewStageDialogControllerSpec.js
+++ b/spec/controllers/NewStageDialogControllerSpec.js
@@ -1,12 +1,12 @@
 describe('NewStageDialogController',function() {
 
-    var module = factory('controllers/NewStageDialogController',{
-        'services/log': logMock,
-    });
-
+    var module;
     var $scope, controller, handshakeMock;
 
     beforeEach(function() {
+        module = factory('controllers/NewStageDialogController',{
+            'services/log': logMock,
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/controllers/RoundDialogControllerSpec.js
+++ b/spec/controllers/RoundDialogControllerSpec.js
@@ -1,12 +1,12 @@
 describe('RoundDialogController',function() {
 
-    var module = factory('controllers/RoundDialogController',{
-        'services/log': logMock,
-    });
-
+    var module;
     var $scope, controller, handshakeMock;
 
     beforeEach(function() {
+        module = factory('controllers/RoundDialogController',{
+            'services/log': logMock,
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/controllers/TeamDialogControllerSpec.js
+++ b/spec/controllers/TeamDialogControllerSpec.js
@@ -1,13 +1,13 @@
 describe('TeamDialogController',function() {
 
-    var module = factory('controllers/TeamDialogController',{
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scope, controller, settingsMock, handshakeMock;
 
     beforeEach(function() {
+        module = factory('controllers/TeamDialogController',{
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/controllers/TeamDialogControllerSpec.js
+++ b/spec/controllers/TeamDialogControllerSpec.js
@@ -2,6 +2,7 @@ describe('TeamDialogController',function() {
 
     var module = factory('controllers/TeamDialogController',{
         'services/log': logMock,
+        'services/fs': {},
     });
 
     var $scope, controller, settingsMock, handshakeMock;

--- a/spec/controllers/TeamImportDialogControllerSpec.js
+++ b/spec/controllers/TeamImportDialogControllerSpec.js
@@ -1,12 +1,12 @@
 describe('TeamImportDialogController',function() {
 
-    var module = factory('controllers/TeamImportDialogController',{
-        'services/log': logMock,
-    });
-
+    var module;
     var $scope, controller, handshakeMock;
 
     beforeEach(function() {
+        module = factory('controllers/TeamImportDialogController',{
+            'services/log': logMock,
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller,$rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/directives/reallySpec.js
+++ b/spec/directives/reallySpec.js
@@ -1,5 +1,9 @@
 describe('really',function() {
-    var module = factory('directives/really');
+    var module;
+
+    beforeEach(function() {
+        module = factory('directives/really');
+    });
 
     var $compile,$rootScope,windowMock = {
         confirm: jasmine.createSpy('confirmSpy')

--- a/spec/directives/reallySpec.js
+++ b/spec/directives/reallySpec.js
@@ -1,8 +1,5 @@
 describe('really',function() {
-    var ngDirectives = factory('directives/ng-directives');
-    var module = factory('directives/really',{
-        'directives/ng-directives': ngDirectives
-    });
+    var module = factory('directives/really');
 
     var $compile,$rootScope,windowMock = {
         confirm: jasmine.createSpy('confirmSpy')

--- a/spec/directives/sigpadSpec.js
+++ b/spec/directives/sigpadSpec.js
@@ -1,14 +1,13 @@
 describe('sigpad',function() {
-    var module = factory('directives/sigpad',{
-        'signaturepad': {},
-    });
-
-
+    var module;
     var $compile,$rootScope,
         regenerateSpy,
         drawEnd;
 
     beforeEach(function() {
+        module = factory('directives/sigpad',{
+            'signaturepad': {},
+        });
         angular.mock.module(module.name);
         inject(function(_$compile_,_$rootScope_) {
             $compile = _$compile_;

--- a/spec/directives/sigpadSpec.js
+++ b/spec/directives/sigpadSpec.js
@@ -1,7 +1,6 @@
 describe('sigpad',function() {
-    var ngDirectives = factory('directives/ng-directives');
     var module = factory('directives/sigpad',{
-        'directives/ng-directives': ngDirectives
+        'signaturepad': {},
     });
 
 

--- a/spec/directives/sizeSpec.js
+++ b/spec/directives/sizeSpec.js
@@ -1,8 +1,5 @@
 describe('size',function() {
-    var ngDirectives = factory('directives/ng-directives');
-    var module = factory('directives/size',{
-        'directives/ng-directives': ngDirectives
-    });
+    var module = factory('directives/size');
 
     var $compile,$rootScope;
 

--- a/spec/directives/sizeSpec.js
+++ b/spec/directives/sizeSpec.js
@@ -1,9 +1,9 @@
 describe('size',function() {
-    var module = factory('directives/size');
-
+    var module;
     var $compile,$rootScope;
 
     beforeEach(function() {
+        module = factory('directives/size');
         angular.mock.module(module.name);
         inject(function(_$compile_,_$rootScope_) {
             $compile = _$compile_;

--- a/spec/directives/spinnerSpec.js
+++ b/spec/directives/spinnerSpec.js
@@ -1,9 +1,9 @@
 xdescribe('spinner',function() {
-    var module = factory('directives/spinner');
-
+    var module;
     var $compile, $scope, $timeout, element, container, frame, prev, next;
 
     beforeEach(function() {
+        module = factory('directives/spinner');
         //add some styling to make it work
         var style = angular.element(multiline(function() {/*
             <style id="spinnerStyle">

--- a/spec/directives/spinnerSpec.js
+++ b/spec/directives/spinnerSpec.js
@@ -1,8 +1,5 @@
 xdescribe('spinner',function() {
-    var ngDirectives = factory('directives/ng-directives');
-    var module = factory('directives/spinner',{
-        'directives/ng-directives': ngDirectives
-    });
+    var module = factory('directives/spinner');
 
     var $compile, $scope, $timeout, element, container, frame, prev, next;
 

--- a/spec/filters/indexSpec.js
+++ b/spec/filters/indexSpec.js
@@ -1,9 +1,9 @@
 describe('indexFilter',function() {
-    var module = factory('filters/index');
-
+    var module;
     var index;
 
     beforeEach(function() {
+        module = factory('filters/index');
         angular.mock.module(module.name);
         angular.mock.inject(function(indexFilter) {
             index = indexFilter;

--- a/spec/filters/indexSpec.js
+++ b/spec/filters/indexSpec.js
@@ -1,8 +1,5 @@
 describe('indexFilter',function() {
-    var ngFilters = factory('filters/ng-filters');
-    var module = factory('filters/index',{
-        'filters/ng-filters': ngFilters
-    });
+    var module = factory('filters/index');
 
     var index;
 

--- a/spec/helpers/defineShim.js
+++ b/spec/helpers/defineShim.js
@@ -5,9 +5,9 @@
  * It adds two functions to the global namespace: define() and factory().
  */
 !function() {
-	var store = {};
+    var store = {};
 
-	function resolve(name, deps, cache) {
+    function resolve(name, deps, cache) {
         if (typeof name !== "string") {
             throw new Error("factory(): invalid module name: " + name);
         }
@@ -16,13 +16,13 @@
             return cache[name];
         }
 
-		if (!store[name]) {
+        if (!store[name]) {
             throw new Error("factory(): module " + name + " is not yet define()'ed");
         }
 
         // Resolve dependencies of this module to either the
         // passed in custom dependencies, or the 'real' ones.
-		var resolvedDeps = store[name].deps.map(function(dep) {
+        var resolvedDeps = store[name].deps.map(function(dep) {
             // Use custom deps, if passed
             if (deps && dep in deps) {
                 return deps[dep];
@@ -80,11 +80,11 @@
             throw new Error("factory(): invalid dependencies (expected an array): " + deps);
         }
         //store factories in a global store
-		store[name] = {
-			factory: factory,
-			deps: deps
-		};
-	};
+        store[name] = {
+            factory: factory,
+            deps: deps
+        };
+    };
 }();
 
 // Pre-register 'well-known' modules

--- a/spec/helpers/defineShim.js
+++ b/spec/helpers/defineShim.js
@@ -7,6 +7,35 @@
 !function() {
     var store = {};
 
+    /**
+     * Resolve the relative path of the require'd module
+     * to the current module's basename.
+     * e.g. if name = "common/foo" and dep = "./bar",
+     * result will be "common/bar".
+     */
+    function resolveRelativeDependency(name, dep) {
+        var base = name.split("/");
+        var relative = dep.split("/");
+        base.pop(); // take the 'filename' off, leaving the 'current folder'
+        if (relative[0] !== "." && relative[0] !== "..") {
+            throw new Error("invalid dependency '" + dep + "' in module '" + name + "': relative path expected");
+        }
+        while (relative.length > 0) {
+            var part = relative.shift();
+            if (part === "" || part === ".") {
+                continue;
+            } else if (part === "..") {
+                if (base.length === 0) {
+                    throw new Error("invalid dependency '" + dep + "' in module '" + name + "': cannot go up this far");
+                }
+                base.pop();
+            } else {
+                base.push(part);
+            }
+        }
+        return base.join("/");
+    }
+
     function resolve(name, deps, cache) {
         if (typeof name !== "string") {
             throw new Error("factory(): invalid module name: " + name);
@@ -20,21 +49,41 @@
             throw new Error("factory(): module " + name + " is not yet define()'ed");
         }
 
-        // Resolve dependencies of this module to either the
-        // passed in custom dependencies, or the 'real' ones.
-        var resolvedDeps = store[name].deps.map(function(dep) {
-            // Use custom deps, if passed
-            if (deps && dep in deps) {
-                return deps[dep];
-            }
-            // Use the 'real' module instead, but make sure that if
-            // that real module uses a dependency that we want to
-            // override, we use that instead.
-            return resolve(dep, deps, cache);
-        });
+        if (store[name].deps !== undefined) {
+            // 'Normal' AMD module, as used in all of our front-end code.
 
-        // Instantiate module
-        cache[name] = store[name].factory.apply(this, resolvedDeps);
+            // Resolve dependencies of this module to either the
+            // passed in custom dependencies, or the 'real' ones.
+            var resolvedDeps = store[name].deps.map(function(dep) {
+                // Use custom deps, if passed
+                if (deps && dep in deps) {
+                    return deps[dep];
+                }
+                // Use the 'real' module instead, but make sure that if
+                // that real module uses a dependency that we want to
+                // override, we use that instead.
+                return resolve(dep, deps, cache);
+            });
+
+            // Instantiate module
+            cache[name] = store[name].factory.apply(this, resolvedDeps);
+        } else {
+            // UMD style module, as used in our common (client+server) code.
+
+            function require(dep) {
+                if (typeof dep !== "string" || dep === "") {
+                    throw new Error("invalid dependency '" + dep + "' in module '" + name + "'");
+                }
+                return resolve(resolveRelativeDependency(name, dep), deps, cache);
+            }
+            var module = { exports: {} };
+            var exports = module.exports;
+
+            // Instantiate module
+            store[name].factory.call(this, require, exports, module);
+            cache[name] = module.exports;
+        }
+
         return cache[name];
     }
 
@@ -70,14 +119,31 @@
      *
      * Shim for RequireJS define functionality.
      *
-     * @see documentation of `factory()` for usage and caveats.
+     * @see documentation of `factory()` for caveats.
+     *
+     * @param name {string} Name of module, e.g. "services/ng-scores"
+     * @param deps {Array<string>} Optional array of dependencies. @see `factory`
+     * @param factory {Function} When deps are given, function receiving deps as args, returning the module, when
+     *            no deps are given, function receiving `require`, `exports`, `module`, returning nothing
+     *            (setting its exports through `exports` or `module.exports`).
      */
     this.define = function(name, deps, factory) {
         if (typeof name !== "string") {
             throw new Error("factory(): invalid module name: " + name);
         }
-        if (!Array.isArray(deps)) {
-            throw new Error("factory(): invalid dependencies (expected an array): " + deps);
+        if (store[name]) {
+            throw new Error("factory(): duplicate module name: " + name);
+        }
+        if (typeof deps === "function") {
+            // This is a UMD-style call, which only passes the module name
+            // and a factory function which expects to receive
+            // `require`, `exports`, and `module`.
+            factory = deps;
+            deps = undefined;
+        } else {
+            if (!Array.isArray(deps)) {
+                throw new Error("factory(): invalid dependencies (expected an array): " + deps);
+            }
         }
         //store factories in a global store
         store[name] = {

--- a/spec/helpers/defineShim.js
+++ b/spec/helpers/defineShim.js
@@ -1,27 +1,92 @@
+/**
+ * This shim replaces RequireJS (which is used outside the tests), and allows
+ * modules to be injected with e.g. mocks instead of the 'real deal', if necessary.
+ *
+ * It adds two functions to the global namespace: define() and factory().
+ */
 !function() {
 	var store = {};
-    var inited = {};
-	this.factory = function(name,deps,force) {
-        if (inited[name] && !force) {
-            return inited[name];
+
+	function resolve(name, deps, cache) {
+        if (typeof name !== "string") {
+            throw new Error("factory(): invalid module name: " + name);
         }
+
+        if (cache[name]) {
+            return cache[name];
+        }
+
 		if (!store[name]) {
-			console.log('unable to find module',name,'in store');
-			console.log(JSON.stringify(store,null,2));
-			return;
-		}
-		deps = deps||{};
+            throw new Error("factory(): module " + name + " is not yet define()'ed");
+        }
+
+        // Resolve dependencies of this module to either the
+        // passed in custom dependencies, or the 'real' ones.
 		var resolvedDeps = store[name].deps.map(function(dep) {
-			return deps[dep]||undefined;
-		});
-        inited[name] = store[name].factory.apply(this,resolvedDeps);
-		return inited[name];
-	};
-	this.define = function(name,deps,factory) {
-		//store factories in a global store
+            // Use custom deps, if passed
+            if (deps && dep in deps) {
+                return deps[dep];
+            }
+            // Use the 'real' module instead, but make sure that if
+            // that real module uses a dependency that we want to
+            // override, we use that instead.
+            return resolve(dep, deps, cache);
+        });
+
+        // Instantiate module
+        cache[name] = store[name].factory.apply(this, resolvedDeps);
+        return cache[name];
+    }
+
+    /**
+     * Instantiate module including dependencies.
+     *
+     * Obtain reference to module, optionally passing in an object of dependencyName => object pairs to
+     * instantiate a version of the module using any 'custom' dependency (e.g. mocked versions).
+     *
+     * All modules (including dependencies) created during the call to factory() are guaranteed to be
+     * instantiated just once within this call to factory(), but the next call to factory() will
+     * use a new module cache.
+     *
+     * Note that the angular and jquery modules behave special, in that they are global instances
+     * that are not (re)created for each call to factory().
+     * This means that every factory call for a module using e.g. ng-services will create a new instance
+     * of the ng-services angular module (angular.module('ng-services', [])), so later calls to
+     * factory() will 'disconnect' that earlier module.
+     * Thus, you must make sure that any call to factory() immediately precedes the tests you're
+     * running, e.g. by placing it in a beforeEach() (not directly in the body of e.g. describe()).
+     *
+     * Shim for RequireJS functionality.
+     *
+     * @param name {string} Name of module to instantiate
+     * @param deps {Object} Optional key-value pairs of dependencies to override
+     */
+    this.factory = function(name, deps) {
+        return resolve(name, deps, {});
+    };
+
+    /**
+     * Define a module to be instantiated later using `factory()`.
+     *
+     * Shim for RequireJS define functionality.
+     *
+     * @see documentation of `factory()` for usage and caveats.
+     */
+    this.define = function(name, deps, factory) {
+        if (typeof name !== "string") {
+            throw new Error("factory(): invalid module name: " + name);
+        }
+        if (!Array.isArray(deps)) {
+            throw new Error("factory(): invalid dependencies (expected an array): " + deps);
+        }
+        //store factories in a global store
 		store[name] = {
 			factory: factory,
 			deps: deps
 		};
 	};
 }();
+
+// Pre-register 'well-known' modules
+define("jquery", [], function() { return $; });
+define("angular", [], function () { return angular; });

--- a/spec/services/defineShimSpec.js
+++ b/spec/services/defineShimSpec.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for our RequireJS 'substitute'.
+ * See defineShim.js itself for reasoning.
+ */
+
+var moduleInstanceCounter = 0;
+
+define('test/amd_module_1', [], function () {
+    return {
+        name: 'amd1',
+        count: moduleInstanceCounter++,
+    };
+});
+
+define('test/amd_module_2', ['test/amd_module_1'], function (mod1) {
+    return {
+        name: 'amd2',
+        mod1: mod1,
+    };
+});
+
+define('test/commonjs_module_1', function (require, exports, module) {
+    var mod1 = require('./amd_module_1');
+    var mod2 = require('./amd_module_2');
+    exports.name = 'cjs1';
+    exports.mod1 = mod1;
+    exports.mod2 = mod2;
+});
+
+define('test/complex', function (require, exports, module) {
+    var cjs1 = require('../foo/..///test/./commonjs_module_1');
+    exports.cjs1 = cjs1;
+});
+
+define('test/broken1', function (require, exports, module) {
+    var cjs1 = require('../../test/commonjs_module_1'); // too deep
+    exports.cjs1 = cjs1;
+});
+
+define('test/broken2', function (require, exports, module) {
+    var cjs1 = require('test/commonjs_module_1'); // not relative path
+    exports.cjs1 = cjs1;
+});
+
+describe('defineShim', function () {
+    it('understands AMD module without dependencies', function () {
+        var mod1 = factory('test/amd_module_1');
+        expect(mod1.name).toBe('amd1');
+    });
+
+    it('understands AMD module with dependencies', function () {
+        var mod2 = factory('test/amd_module_2');
+        expect(mod2.name).toBe('amd2');
+        expect(mod2.mod1.name).toBe('amd1');
+    });
+
+    it('understands commonJS module with dependencies', function () {
+        var mod3 = factory('test/commonjs_module_1');
+        expect(mod3.name).toBe('cjs1');
+        expect(mod3.mod2.mod1.name).toBe('amd1');
+    });
+
+    it('understands commonJS module dependency relative paths', function () {
+        var mod = factory('test/complex');
+        expect(mod.cjs1.name).toBe('cjs1');
+    });
+
+    it('prevents commonJS module dependency going up too far', function () {
+        expect(function () {
+            var mod = factory('test/broken1');
+        }).toThrowError(/cannot go up/);
+    });
+
+    it('prevents commonJS module dependency absolute paths', function () {
+        expect(function () {
+            var mod = factory('test/broken2');
+        }).toThrowError(/relative path/);
+    });
+
+    it('allows customizing dependencies', function () {
+        var mod2 = factory('test/amd_module_2', {
+            'test/amd_module_1': { name: 'replaced' },
+        });
+        expect(mod2.name).toBe('amd2');
+        expect(mod2.mod1.name).toBe('replaced');
+    });
+
+    it('allows customizing sub dependencies', function () {
+        var mod3 = factory('test/commonjs_module_1', {
+            'test/amd_module_1': { name: 'replaced' },
+        });
+        expect(mod3.name).toBe('cjs1');
+        expect(mod3.mod2.mod1.name).toBe('replaced');
+    });
+
+    it('instantiates modules ones within one factory call', function () {
+        var mod3 = factory('test/commonjs_module_1');
+        expect(mod3.mod2.mod1.count).toBe(mod3.mod1.count);
+    });
+
+    it('reinstantiates modules between factory calls', function () {
+        var a = factory('test/amd_module_1');
+        var b = factory('test/amd_module_1');
+        expect(b.count).toBe(a.count + 1);
+    });
+
+    it('throws on duplicate module name', function () {
+        expect(function () {
+            define('test/amd_module_1', [], function () { });
+        }).toThrowError(/duplicate module name/);
+    });
+
+    it('throws on invalid module name', function () {
+        expect(function () {
+            define({}, [], function () { });
+        }).toThrowError(/invalid module name/);
+    });
+
+    it('throws on invalid AMD dependencies', function () {
+        expect(function () {
+            define('test/something', {}, function () { });
+        }).toThrowError(/invalid dependencies/);
+    });
+});

--- a/spec/services/fs-nwSpec.js
+++ b/spec/services/fs-nwSpec.js
@@ -4,7 +4,7 @@ describe('fs-nw',function() {
         var fs = factory('services/fs-nw',{
             'q':Q,
             'idbstore': window.IDBStore
-        },true);
+        });
         describe('reading',function() {
             it('should read a test file',function() {
                 return fs.write('foo/foo.txt','jsfd978sd').then(function() {

--- a/spec/services/fs-nwSpec.js
+++ b/spec/services/fs-nwSpec.js
@@ -1,10 +1,14 @@
 describe('fs-nw',function() {
 
     describe('store exists',function() {
-        var fs = factory('services/fs-nw',{
-            'q':Q,
-            'idbstore': window.IDBStore
+        var fs;
+        beforeEach(function() {
+            fs = factory('services/fs-nw',{
+                'q':Q,
+                'idbstore': window.IDBStore
+            });
         });
+
         describe('reading',function() {
             it('should read a test file',function() {
                 return fs.write('foo/foo.txt','jsfd978sd').then(function() {

--- a/spec/services/fs-pgSpec.js
+++ b/spec/services/fs-pgSpec.js
@@ -1,13 +1,13 @@
 describe('fs-pg',function() {
 
-    var fs = factory('services/fs-pg',{
-        'q':Q,
-        'services/log': logMock
-    });
-
+    var fs;
     var FileEntry, DirectoryEntry, FileSystem, FileReader, FileWriter;
 
     beforeEach(function() {
+        fs = factory('services/fs-pg',{
+            'q':Q,
+            'services/log': logMock
+        });
         //fake local filesystem as provided by phonegap
         //TODO: maybe extract phonegap fs mock?
         window.LocalFileSystem = {

--- a/spec/services/fs-xhrSpec.js
+++ b/spec/services/fs-xhrSpec.js
@@ -15,9 +15,12 @@ describe('fs-xhr',function() {
         ajax: jasmine.createSpy('jqajax').and.returnValue(createJQPromise('ajax'))
     };
 
-    var fs = factory('services/fs-xhr',{
-        'q':Q,
-        'jquery': fakeJQuery
+    var fs;
+    beforeEach(function() {
+        fs = factory('services/fs-xhr',{
+            'q':Q,
+            'jquery': fakeJQuery
+        });
     });
 
     describe('fs signature',function() {

--- a/spec/services/logSpec.js
+++ b/spec/services/logSpec.js
@@ -1,5 +1,8 @@
 describe('log',function() {
-    var log = factory('services/log');
+    var log;
+    beforeEach(function() {
+        log = factory('services/log');
+    });
 
     describe('logging',function() {
         beforeEach(function() {

--- a/spec/services/logSpec.js
+++ b/spec/services/logSpec.js
@@ -1,7 +1,5 @@
 describe('log',function() {
-    var log = factory('services/log',{
-        jquery: $
-    });
+    var log = factory('services/log');
 
     describe('logging',function() {
         beforeEach(function() {

--- a/spec/services/ng-challengeSpec.js
+++ b/spec/services/ng-challengeSpec.js
@@ -1,5 +1,4 @@
 describe('ng-challenge',function() {
-    var ngServices = factory('services/ng-services');
     var challenge, q;
 
     var dummyChallenge = {foo:'bar'};
@@ -9,7 +8,6 @@ describe('ng-challenge',function() {
 
     var module = factory('services/ng-challenge',{
         'services/log': logMock,
-        'services/ng-services': ngServices,
         'services/fs': fsMock
     });
 

--- a/spec/services/ng-challengeSpec.js
+++ b/spec/services/ng-challengeSpec.js
@@ -6,12 +6,13 @@ describe('ng-challenge',function() {
     var fsMock, settingsMock,$q,$rootScope,$httpBackend;
     fsMock = createFsMock({'foo': JSON.stringify(dummyChallenge)});
 
-    var module = factory('services/ng-challenge',{
-        'services/log': logMock,
-        'services/fs': fsMock
-    });
+    var module;
 
     beforeEach(function() {
+        module = factory('services/ng-challenge',{
+            'services/log': logMock,
+            'services/fs': fsMock
+        });
         angular.mock.module(module.name);
         angular.mock.module(function($provide) {
             $provide.service('$settings', function($q) {

--- a/spec/services/ng-fsSpec.js
+++ b/spec/services/ng-fsSpec.js
@@ -1,8 +1,6 @@
 describe('ng-fs',function() {
-    var ngServices = factory('services/ng-services');
     var fsMock = createFsMock({'foo': '"dummydata"'});
     var module = factory('services/ng-fs',{
-        'services/ng-services': ngServices,
         'services/fs': fsMock
     });
 

--- a/spec/services/ng-fsSpec.js
+++ b/spec/services/ng-fsSpec.js
@@ -1,12 +1,12 @@
 describe('ng-fs',function() {
     var fsMock = createFsMock({'foo': '"dummydata"'});
-    var module = factory('services/ng-fs',{
-        'services/fs': fsMock
-    });
-
-    var $fs
+    var module;
+    var $fs;
 
     beforeEach(function() {
+        module = factory('services/ng-fs',{
+            'services/fs': fsMock
+        });
         angular.mock.module(module.name);
         angular.mock.inject(['$fs',function(fs) {
             $fs = fs;

--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -1,9 +1,8 @@
 describe('ng-scores',function() {
     "use strict";
-    var ngServices = factory('services/ng-services');
     var module = factory('services/ng-scores',{
-        'services/ng-services': ngServices,
-        'services/log': logMock
+        'services/log': logMock,
+        'services/fs': {},
     });
 
     var $scores;

--- a/spec/services/ng-scoresSpec.js
+++ b/spec/services/ng-scoresSpec.js
@@ -1,10 +1,6 @@
 describe('ng-scores',function() {
     "use strict";
-    var module = factory('services/ng-scores',{
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scores;
     var $stages;
     var $teams;
@@ -31,6 +27,10 @@ describe('ng-scores',function() {
     var fsMock;
 
     beforeEach(function() {
+        module = factory('services/ng-scores',{
+            'services/log': logMock,
+            'services/fs': {},
+        });
         fsMock = createFsMock({
             "scores.json": { version: 2, scores: [rawMockScore], sheets: [] },
             "stages.json": [rawMockStage],
@@ -561,3 +561,4 @@ describe('ng-scores',function() {
     });
 
 });
+

--- a/spec/services/ng-settingsSpec.js
+++ b/spec/services/ng-settingsSpec.js
@@ -1,8 +1,7 @@
 describe('ng-settings',function() {
-    var ngServices = factory('services/ng-services');
     var module = factory('services/ng-settings',{
-        'services/ng-services': ngServices,
-        'services/log': logMock
+        'services/log': logMock,
+        'services/fs': {},
     });
 
     var $settings, $httpBackend, $q, $rootScope, settingsMock, fsMock;

--- a/spec/services/ng-settingsSpec.js
+++ b/spec/services/ng-settingsSpec.js
@@ -1,12 +1,12 @@
 describe('ng-settings',function() {
-    var module = factory('services/ng-settings',{
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $settings, $httpBackend, $q, $rootScope, settingsMock, fsMock;
 
     beforeEach(function() {
+        module = factory('services/ng-settings',{
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.module(function($provide) {
             var s = $provide.service('$fs',function($q) {

--- a/spec/services/ng-stagesSpec.js
+++ b/spec/services/ng-stagesSpec.js
@@ -1,10 +1,7 @@
 describe('ng-stages',function() {
     "use strict";
 
-    var module = factory('services/ng-stages',{
-        'services/log': logMock
-    });
-
+    var module;
     var $rootScope;
     var $stages;
     var $q;
@@ -16,6 +13,10 @@ describe('ng-stages',function() {
 
     //initialize
     beforeEach(function() {
+        module = factory('services/ng-stages',{
+            'services/log': logMock,
+            'services/fs': {}
+        });
         mockStage = { id: "practice", name: "Practice Rounds", rounds: 2 };
         mockStageSanitized = { index: 0, id: "practice", name: "Practice Rounds", rounds: 2, $rounds: [1, 2] };
         unusedMockStage = { id: "unused", name: "Foobar", rounds: 0 };

--- a/spec/services/ng-stagesSpec.js
+++ b/spec/services/ng-stagesSpec.js
@@ -1,9 +1,7 @@
 describe('ng-stages',function() {
     "use strict";
 
-    var ngServices = factory('services/ng-services');
     var module = factory('services/ng-stages',{
-        'services/ng-services': ngServices,
         'services/log': logMock
     });
 

--- a/spec/services/ng-teamsSpec.js
+++ b/spec/services/ng-teamsSpec.js
@@ -1,8 +1,7 @@
 describe('ng-teams',function() {
-    var ngServices = factory('services/ng-services');
     var module = factory('services/ng-teams',{
-        'services/ng-services': ngServices,
-        'services/log': logMock
+        'services/log': logMock,
+        'services/fs': {},
     });
 
     var $teams;

--- a/spec/services/ng-teamsSpec.js
+++ b/spec/services/ng-teamsSpec.js
@@ -1,9 +1,5 @@
 describe('ng-teams',function() {
-    var module = factory('services/ng-teams',{
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $teams;
     var rawMockTeam = { number: "123", name: "Oefenrondes", cityState: "foo" };
     var rawMockTeam2 = { number: "123", name: "Oefenrondes", translationNeeded: true };
@@ -48,6 +44,10 @@ describe('ng-teams',function() {
     var fsMock;
 
     beforeEach(function() {
+        module = factory('services/ng-teams',{
+            'services/log': logMock,
+            'services/fs': {},
+        });
         fsMock = createFsMock({"teams.json": [rawMockTeam]});
         angular.mock.module(module.name);
         angular.mock.module(function($provide) {

--- a/spec/services/ng-throttleSpec.js
+++ b/spec/services/ng-throttleSpec.js
@@ -1,8 +1,5 @@
 describe('ng-throttle',function() {
-    var ngServices = factory('services/ng-services');
-    var module = factory('services/ng-throttle',{
-        'services/ng-services': ngServices
-    });
+    var module = factory('services/ng-throttle');
 
     var $throttle,$timeout;
 

--- a/spec/services/ng-throttleSpec.js
+++ b/spec/services/ng-throttleSpec.js
@@ -1,9 +1,9 @@
 describe('ng-throttle',function() {
-    var module = factory('services/ng-throttle');
-
+    var module;
     var $throttle,$timeout;
 
     beforeEach(function() {
+        module = factory('services/ng-throttle');
         angular.mock.module(module.name);
         angular.mock.inject(function(_$throttle_,_$timeout_) {
             $throttle = _$throttle_;

--- a/spec/views/rankingSpec.js
+++ b/spec/views/rankingSpec.js
@@ -2,7 +2,7 @@ describe('ranking', function() {
 
     var module = factory('views/ranking', {
         'services/log': logMock,
-        'controllers/ExportRankingDialogController': factory('controllers/ExportRankingDialogController')
+        'services/fs': {},
     });
 
     var $scope, controller;

--- a/spec/views/rankingSpec.js
+++ b/spec/views/rankingSpec.js
@@ -1,10 +1,6 @@
 describe('ranking', function() {
 
-    var module = factory('views/ranking', {
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scope, controller;
     var dummyTeam = {
         number: '123',
@@ -13,6 +9,10 @@ describe('ranking', function() {
     var fsMock, stagesMock, scoresMock, handshakeMock, messageMock;
 
     beforeEach(function() {
+        module = factory('views/ranking', {
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller, $rootScope,$q) {
             $scope = $rootScope.$new();

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -1,14 +1,14 @@
 describe('scores', function() {
 
-    var module = factory('views/scores', {
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scope, controller, scoresMock, teamsMock, stagesMock,$window,$q;
     var originalMockScores;
 
     beforeEach(function() {
+        module = factory('views/scores', {
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller, $rootScope,_$window_,_$q_) {
             $scope = $rootScope.$new();

--- a/spec/views/scoresSpec.js
+++ b/spec/views/scoresSpec.js
@@ -1,7 +1,8 @@
 describe('scores', function() {
 
     var module = factory('views/scores', {
-        'services/log': logMock
+        'services/log': logMock,
+        'services/fs': {},
     });
 
     var $scope, controller, scoresMock, teamsMock, stagesMock,$window,$q;

--- a/spec/views/scoresheetSpec.js
+++ b/spec/views/scoresheetSpec.js
@@ -1,11 +1,6 @@
 describe('scoresheet',function() {
 
-    var module = factory('views/scoresheet',{
-        'services/log': logMock,
-        'services/fs': {},
-        'signaturepad': {},
-    });
-
+    var module;
     var $scope, controller, $window;
     var dummyTeam =  {
         number: '123',
@@ -16,6 +11,11 @@ describe('scoresheet',function() {
     var settingsMock, handshakeMock, challengeMock;
 
     beforeEach(function() {
+        module = factory('views/scoresheet',{
+            'services/log': logMock,
+            'services/fs': {},
+            'signaturepad': {},
+        });
         angular.mock.module('DescriptionDialog');
         angular.mock.module('TeamDialog');
         angular.mock.module('RoundDialog');

--- a/spec/views/scoresheetSpec.js
+++ b/spec/views/scoresheetSpec.js
@@ -2,9 +2,8 @@ describe('scoresheet',function() {
 
     var module = factory('views/scoresheet',{
         'services/log': logMock,
-        'controllers/DescriptionDialogController': factory('controllers/DescriptionDialogController'),
-        'controllers/TeamDialogController': factory('controllers/TeamDialogController'),
-        'controllers/RoundDialogController': factory('controllers/RoundDialogController')
+        'services/fs': {},
+        'signaturepad': {},
     });
 
     var $scope, controller, $window;

--- a/spec/views/settingsSpec.js
+++ b/spec/views/settingsSpec.js
@@ -2,7 +2,7 @@ describe('settings', function() {
 
     var module = factory('views/settings', {
         'services/log': logMock,
-        'controllers/NewStageDialogController': factory('controllers/NewStageDialogController')
+        'services/fs': {},
     });
 
     var $scope, controller;

--- a/spec/views/settingsSpec.js
+++ b/spec/views/settingsSpec.js
@@ -1,15 +1,14 @@
 describe('settings', function() {
 
-    var module = factory('views/settings', {
-        'services/log': logMock,
-        'services/fs': {},
-    });
-
+    var module;
     var $scope, controller;
-
     var settingsMock, handshakeMock, stagesMock, challengesMock;
 
     beforeEach(function() {
+        module = factory('views/settings', {
+            'services/log': logMock,
+            'services/fs': {},
+        });
         angular.mock.module(module.name);
         angular.mock.inject(function($controller, $rootScope, $q) {
             $scope = $rootScope.$new();

--- a/spec/views/teamsSpec.js
+++ b/spec/views/teamsSpec.js
@@ -2,8 +2,7 @@ describe('teams', function() {
 
     var module = factory('views/teams', {
         'services/log': logMock,
-        'services/ng-throttle': factory('services/ng-throttle'),
-        'controllers/TeamImportDialogController': factory('controllers/TeamImportDialogController')
+        'services/fs': {},
     });
 
     var $scope, controller, $httpBackend, $teams, handshakeMock;

--- a/spec/views/teamsSpec.js
+++ b/spec/views/teamsSpec.js
@@ -1,8 +1,11 @@
 describe('teams', function() {
 
-    var module = factory('views/teams', {
-        'services/log': logMock,
-        'services/fs': {},
+    var module;
+    beforeEach(function() {
+        module = factory('views/teams', {
+            'services/log': logMock,
+            'services/fs': {},
+        });
     });
 
     var $scope, controller, $httpBackend, $teams, handshakeMock;

--- a/src/js/services/ng-scores.js
+++ b/src/js/services/ng-scores.js
@@ -6,7 +6,8 @@ define('services/ng-scores',[
     'services/ng-services',
     'services/log',
     'services/ng-fs',
-    'services/ng-stages'
+    'services/ng-stages',
+    'services/ng-teams',
 ],function(module,log) {
     "use strict";
 


### PR DESCRIPTION
It appeared (while working on #281 and on refactoring ranking out to common code) that something is fairly broken with the way the `factory()` function is used in our tests.

The original idea was to replace RequireJS while running the tests, in order to allow passing e.g. mocks as dependencies for the modules. (Note that Angular itself provides a similar mechanism, too.)

The way `factory()` worked, though, is that it cached the first invocation, which means that any later invocations would get that module with a potentially different set of dependencies. These could be mocked dependencies, or could even be missing, because there was no check for such missing dependencies.

Specifically, e.g. adding a dependency in e.g. ng-scores worked fine in 'real life', but fails mysteriously in tests. This appears to be caused because another tests already instantiated ng-scores, but failed to pass this new reference, and that instance was then cached.

This PR fixes this by making any call to factory return a new 'eco system' of modules (all of them are re-instantiated). However, because there is only one instance of angular, any angular modules defined as such will overwrite each other, so the calls to `factory()` must directly precede the actual tests. Hence the move to `beforeEach()`.

As a side-effect, a missing dependency in ng-scores was found, which is now fixed.

Note that modules that use the `$fs` service are changed to have a dummy-module for `services/fs`, which is fine in that case, because the mocked `$fs` doesn't use `services/fs`.