### PR TITLE
Fix relative urls

### DIFF
--- a/src/css/materialIcons.css
+++ b/src/css/materialIcons.css
@@ -1,25 +1,25 @@
 /* fallback */
 @font-face {
-  font-family: 'Material Icons';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Material Icons'), local('MaterialIcons-Regular'), url(/fonts/materialIcons.woff2) format('woff2');
+    font-family: 'Material Icons';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Material Icons'), local('MaterialIcons-Regular'), url(/fonts/materialIcons.woff2) format('woff2');
 }
 
 .material-icons {
-  font-family: 'Material Icons';
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
-  -moz-font-feature-settings: 'liga';
-  -moz-osx-font-smoothing: grayscale;
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+    -moz-font-feature-settings: 'liga';
+    -moz-osx-font-smoothing: grayscale;
 }

--- a/src/css/materialIcons.css
+++ b/src/css/materialIcons.css
@@ -3,7 +3,7 @@
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: local('Material Icons'), local('MaterialIcons-Regular'), url(/fonts/materialIcons.woff2) format('woff2');
+    src: local('Material Icons'), local('MaterialIcons-Regular'), url(../fonts/materialIcons.woff2) format('woff2');
 }
 
 .material-icons {

--- a/src/js/services/session.js
+++ b/src/js/services/session.js
@@ -1,37 +1,37 @@
-define('services/session',[
-	'services/ng-services',
-], function(module) {
+define('services/session', [
+    'services/ng-services',
+], function (module) {
 
-	return module.service('session', [
-		'$http',
-		function($http) {
-	
-		var eventListeners = [];
-		var session = {};
+    return module.service('session', [
+        '$http',
+        function ($http) {
 
-		$http.get('/session').then(function(response) {
-			for(var key in response.data) {
-				session[key] = response.data[key];
-			}
+            var eventListeners = [];
+            var session = {};
 
-			eventListeners.forEach(function(eventListener) {
-				eventListener();
-			});
-		});
+            $http.get('/session').then(function (response) {
+                for (var key in response.data) {
+                    session[key] = response.data[key];
+                }
 
-	    return {
-	    	get: function(key) {
-	    		return session[key];
-		    },
-		    keys: function() {
-		    	return Object.keys(session);
-		    },
-		    onload: function(func) {
-		    	if(typeof func === 'function') {
-		    		eventListeners.push(func);
-		    	}
-		    }
-		};
+                eventListeners.forEach(function (eventListener) {
+                    eventListener();
+                });
+            });
 
-	}]);
+            return {
+                get: function (key) {
+                    return session[key];
+                },
+                keys: function () {
+                    return Object.keys(session);
+                },
+                onload: function (func) {
+                    if (typeof func === 'function') {
+                        eventListeners.push(func);
+                    }
+                }
+            };
+        }
+    ]);
 });

--- a/src/js/services/session.js
+++ b/src/js/services/session.js
@@ -9,7 +9,7 @@ define('services/session', [
             var eventListeners = [];
             var session = {};
 
-            $http.get('/session').then(function (response) {
+            $http.get('session').then(function (response) {
                 for (var key in response.data) {
                     session[key] = response.data[key];
                 }


### PR DESCRIPTION
When using fllscoring from fllproxy (https://github.com/FirstLegoLeague/fllproxy), the front-end comes up almost completely empty.

fllproxy 'inserts' a base URL with the country/region in front of the fllscoring URLs, e.g. `domain.com/myregion/...`. fllscoring used to work completely with these relative URLs, but this was apparently broken in relatively recent commits.

The main cause of emptiness was that the `session` service uses an absolute path, and the material UI icons stopped working due to a similar absolute path.

Both have been fixed, including newline and other whitespace issues (as separate commits).